### PR TITLE
Added positive status message for the production mode check

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,7 @@
 # 0.1.0
 
 * Erster Release im Store
+
+# 0.1.1
+
+* Positive Statusnachricht für den Produktivmodus Check hinzugefügt. 

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,7 @@
 # 0.1.0
 
 * First release in Store
+
+# 0.1.1
+
+* Added positive status message for the production mode check. 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "frosh/tools",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Provides some basic things for managing the Shopware Installation",
     "type": "shopware-platform-plugin",
     "license": "MIT",

--- a/src/Components/Health/Checker/ProductionChecker.php
+++ b/src/Components/Health/Checker/ProductionChecker.php
@@ -18,6 +18,10 @@ class ProductionChecker implements CheckerInterface
     {
         if ($this->environment !== 'prod') {
             $collection->add(HealthResult::error('frosh-tools.checker.not-prod'));
+
+            return;
         }
+
+        $collection->add(HealthResult::ok('frosh-tools.checker.prodGood'));
     }
 }

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -64,7 +64,8 @@
       "zendOpcacheWarning": "Zend Opcache ist nicht aktiv",
       "queuesGood": "Warteschlange läuft regelmäßig",
       "queuesWarning": "Warteschlange enthält Daten, die älter als {minutes} Minuten sind",
-      "not-prod": "Shop ist nicht im produktivmodus"
+      "not-prod": "Shop ist nicht im Produktivmodus",
+      "prodGood": "Shop ist im Produktivmodus"
     },
     "size": "Größe",
     "resetQueue": "Queue zurücksetzen",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -64,7 +64,8 @@
       "zendOpcacheWarning": "Zend Opcache is not active",
       "queuesGood": "Queues working good",
       "queuesWarning": "Queues are older than {minutes} minutes",
-      "not-prod": "Shop is not in production mode"
+      "not-prod": "Shop is not in production mode",
+      "prodGood": "Shop is in production mode"
     },
     "size": "Size",
     "resetQueue": "Reset Queue",


### PR DESCRIPTION
The system status entry disappears, when the shop is in production mode. Added missing status message for the production check.