### PR TITLE
chore: updated changelog

### DIFF
--- a/.github/workflows/store.yml
+++ b/.github/workflows/store.yml
@@ -37,7 +37,7 @@ jobs:
         needs: validatePlugin
         name: Update Store page
         container: ghcr.io/friendsofshopware/platform-plugin-dev:v6.4.0
-        if: startsWith(github.ref, 'refs/tags/') != true
+        if: startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[store update]')
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -7,7 +7,8 @@
 * Positive Statusnachricht für den Produktivmodus Check hinzugefügt. 
 * Verbesserungen der Administration-Oberfläche.
 * Max-Execution-Time Prüfung zum System Status hinzugefügt.
-
-# 0.1.2
-
+* Sortierung von Geplanten Aufgaben und Caches angepasst
+* Schaltflächen zum Aktualisieren von Daten in allen Komponenten hinzugefügt
+* Vergleichen-Funktion im Shopware-Files-Checker hinzugefügt
+* Wiederherstellen-Funktion im Shopware-Files-Checker hinzugefügt
 * Feature Flag Manager hinzugefügt

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -7,7 +7,8 @@
 * Added positive status message for the production mode check. 
 * Administration view improvements.
 * Added Max-Execution-Time check to system status.
-
-# 0.1.2
-
+* Adjusted sorting of Tasks and Caches.
+* Added buttons to refresh data in all components.
+* Added Diff-Function in Shopware-Files-Checker.
+* Added Restore-Function in Shopware-Files-Checker.
 * Added Feature Flag Manager

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "frosh/tools",
-    "version": "0.1.2",
+    "version": "0.1.1",
     "description": "Provides some basic things for managing the Shopware Installation",
     "type": "shopware-platform-plugin",
     "license": "MIT",


### PR DESCRIPTION
- there was no 0.1.1 yet
- we should prevent store data to be updated with content not yet valid for released versions