### PR TITLE
Exclude inactive tasks from health check

### DIFF
--- a/src/Components/Health/Checker/TaskChecker.php
+++ b/src/Components/Health/Checker/TaskChecker.php
@@ -8,6 +8,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 
 class TaskChecker implements CheckerInterface
 {
@@ -35,6 +38,12 @@ class TaskChecker implements CheckerInterface
                 ['lte' => $date->format(\DATE_ATOM)]
             )
         );
+        $criteria->addFilter(new NotFilter(
+            NotFilter::CONNECTION_AND, 
+            [
+                new EqualsFilter('status', ScheduledTaskDefinition::STATUS_INACTIVE)
+            ]
+        ));
 
         $oldTasks = $this->scheduledTaskRepository
             ->searchIds($criteria, Context::createDefaultContext())->getIds();


### PR DESCRIPTION
If a task is set to inactive, the status always reports as unhealthy, because inactive tasks may not running for a long period. By excluding inactive tasks, the state can be reported correctly.