### PR TITLE
fix: handle `iterable` response in scheduled task controller

### DIFF
--- a/src/Controller/ScheduledTaskController.php
+++ b/src/Controller/ScheduledTaskController.php
@@ -55,7 +55,11 @@ class ScheduledTaskController
                 continue;
             }
 
-            if (!in_array($className, $handler::getHandledMessages(), true)) {
+            $handledMessages = $handler::getHandledMessages();
+            if (!is_array($handledMessages)) {
+                $handledMessages = iterator_to_array($handledMessages);
+            }
+            if (!in_array($className, $handledMessages, true)) {
                 continue;
             }
 


### PR DESCRIPTION
The method `AbstractMessageHandler::getHandledMessages()` has `iterable` as its return type, but the code in
`ScheduledTaskController` assumed that its result can be passed as the second argument to `in_array()`. This causes errors when using the "start manually" button in the scheduled tasks manager UI.

Change this to convert the result into an array before passsing it into `in_array()`.