### PR TITLE
deprecated routescope annotation

### DIFF
--- a/src/Controller/CacheController.php
+++ b/src/Controller/CacheController.php
@@ -4,13 +4,11 @@ namespace Frosh\Tools\Controller;
 
 use Frosh\Tools\Components\CacheHelper;
 use Frosh\Tools\Components\CacheRegistry;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
- * @Route(path="/api/_action/frosh-tools")
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
  */
 class CacheController
 {

--- a/src/Controller/ElasticsearchController.php
+++ b/src/Controller/ElasticsearchController.php
@@ -3,15 +3,13 @@
 namespace Frosh\Tools\Controller;
 
 use Frosh\Tools\Components\Elasticsearch\ElasticsearchManager;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
- * @Route(path="/api/_action/frosh-tools/elasticsearch")
+ * @Route(path="/api/_action/frosh-tools/elasticsearch", defaults={"_routeScope"={"api"}})
  */
 class ElasticsearchController
 {

--- a/src/Controller/FeatureFlagController.php
+++ b/src/Controller/FeatureFlagController.php
@@ -4,7 +4,6 @@ namespace Frosh\Tools\Controller;
 
 use Frosh\Tools\Components\Environment\EnvironmentManager;
 use Shopware\Core\Framework\Feature;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Exception\InvalidRequestParameterException;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -14,8 +13,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
- * @Route(path="/api/_action/frosh-tools")
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
  */
 class FeatureFlagController
 {

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -5,13 +5,11 @@ namespace Frosh\Tools\Controller;
 use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\PerformanceCollection;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
- * @Route(path="/api/_action/frosh-tools")
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
  */
 class HealthController
 {

--- a/src/Controller/LogController.php
+++ b/src/Controller/LogController.php
@@ -3,7 +3,6 @@
 namespace Frosh\Tools\Controller;
 
 use Frosh\Tools\Components\LineReader;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Exception\InvalidRequestParameterException;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Symfony\Component\Finder\Finder;
@@ -13,8 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
- * @Route(path="/api/_action/frosh-tools")
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
  */
 class LogController
 {

--- a/src/Controller/QueueController.php
+++ b/src/Controller/QueueController.php
@@ -4,13 +4,11 @@ namespace Frosh\Tools\Controller;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
- * @Route(path="/api/_action/frosh-tools")
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
  */
 class QueueController
 {

--- a/src/Controller/ScheduledTaskController.php
+++ b/src/Controller/ScheduledTaskController.php
@@ -8,13 +8,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\MessageQueue\Handler\AbstractMessageHandler;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
- * @Route(path="/api/_action/frosh-tools")
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
  */
 class ScheduledTaskController
 {

--- a/src/Controller/ShopwareFilesController.php
+++ b/src/Controller/ShopwareFilesController.php
@@ -2,15 +2,13 @@
 
 namespace Frosh\Tools\Controller;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Kernel;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"api"})
- * @Route(path="/api/_action/frosh-tools")
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
  */
 class ShopwareFilesController
 {


### PR DESCRIPTION
Using the V6_5_0_0 feature flag, the "RouteScope" annotations are throwing deprecation messages.
This PR will replace the affected annotations in the controllers.