### PR TITLE
fix: set nextExecutionTime to prevent stacking of calculating nextExecutionTime

### DIFF
--- a/src/Controller/ScheduledTaskController.php
+++ b/src/Controller/ScheduledTaskController.php
@@ -43,6 +43,7 @@ class ScheduledTaskController
             [
                 'id' => $id,
                 'status' => ScheduledTaskDefinition::STATUS_QUEUED,
+                'nextExecutionTime' => new \DateTime(),
             ],
         ], $context);
 


### PR DESCRIPTION
https://github.com/shopware/platform/blob/37dcd398e8429c0f7d9cdfa79d9df72b44955390/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandler.php#L85

Running the task manually will add the intervall onto existing nextExecutionTime, which can be result in task unexpected running in the distant future.