### PR TITLE
Add mailing command

### DIFF
--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -23,6 +23,8 @@ class MonitorCommand extends Command
 {
     private const MONITOR_EMAIL_OPTION = 'email';
     private const MONITOR_SALESCHANNEL_ARG = 'sales-channel';
+    public static $defaultName = 'frosh:monitor';
+    public static $defaultDescription = 'Monitor your scheduled task and queue with this command and get notified via email.';
 
     private AbstractMailService       $mailService;
     private SystemConfigService       $configService;
@@ -40,10 +42,8 @@ class MonitorCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName('frosh:monitor');
         $this->addArgument('sales-channel', InputArgument::REQUIRED, 'Sales Channel ID.');
         $this->addOption(self::MONITOR_EMAIL_OPTION, 'em', InputOption::VALUE_OPTIONAL, 'Custom mail address');
-        $this->setDescription('');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+
+namespace Frosh\Tools\Command;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Mail\Service\AbstractMailService;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class MonitorCommand extends Command
+{
+    private const MONITOR_EMAIL_OPTION = 'email';
+    private const MONITOR_SALESCHANNEL_ARG = 'sales-channel';
+
+    private AbstractMailService       $mailService;
+    private SystemConfigService       $configService;
+    private Connection                $connection;
+    private EntityRepositoryInterface $scheduledTaskRepository;
+
+    public function __construct(AbstractMailService $mailService, SystemConfigService $configService, Connection $connection, EntityRepositoryInterface $scheduledTaskRepository)
+    {
+        parent::__construct();
+        $this->mailService = $mailService;
+        $this->configService = $configService;
+        $this->connection = $connection;
+        $this->scheduledTaskRepository = $scheduledTaskRepository;
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('frosh:monitor');
+        $this->addArgument('sales-channel', InputArgument::REQUIRED, 'Sales Channel ID.');
+        $this->addOption(self::MONITOR_EMAIL_OPTION, 'em', InputOption::VALUE_OPTIONAL, 'Custom mail address');
+        $this->setDescription('');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $context = Context::createDefaultContext();
+
+        if ($input->getOption(self::MONITOR_EMAIL_OPTION)) {
+            $recepientMail = $input->getOption(self::MONITOR_EMAIL_OPTION);
+            $errorSource = 'CLI option';
+        } else {
+            $recepientMail = $this->configService->getString(
+                'FroshTools.config.monitorMail');
+            $errorSource = 'plugin config';
+        }
+
+        if (!filter_var($recepientMail, \FILTER_VALIDATE_EMAIL)) {
+            $output->writeln('<error>Invalid email format in ' . $errorSource . '</error>');
+
+            return self::INVALID;
+        }
+
+        if (!empty($recepientMail) && ($this->queueFailed() || $this->scheduledTaskFailed())) {
+            $data = new ParameterBag();
+            $data->set(
+                'recipients',
+                [
+                    $recepientMail => 'Admin',
+                ]
+            );
+            $data->set('senderName', 'Froshtools | Admin');
+
+            $htmlMailContent = <<<'MAIL'
+                <div style="font-family:arial; font-size:12px;">
+                    <p>
+                        Dear Admin,<br/>
+                        <br/>
+                        your message queue or scheduled tasks are not working as expected.<br/>
+                        <br/>
+                        <br/>
+                        Check your queues and tasks <a href="{{ salesChannel.domains|first.url }}/admin#/frosh/tools/index/index">here</a>
+                    </p>
+                </div>
+                MAIL;
+            $plainMailContent = 'Dear Admin,your message queue or scheduled tasks are not working as expected.Check your queues and tasks {{ salesChannel.domains|first.url }}/admin#/frosh/tools/index/index';
+
+            $data->set('contentHtml', $htmlMailContent);
+            $data->set('contentPlain', $plainMailContent);
+            $data->set('salesChannelId', $input->getArgument(self::MONITOR_SALESCHANNEL_ARG));
+            $data->set('subject', 'Froshtools message queue and scheduled task | Warning');
+
+            $this->mailService->send($data->all(), $context);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function queueFailed(): bool
+    {
+        $oldestMessage = (int) $this->connection->fetchOne('SELECT IFNULL(MIN(published_at), 0) FROM enqueue');
+        $oldestMessage /= 10000;
+        $minutes = $this->configService->getInt(
+            'FroshTools.config.monitorQueueGraceTime');
+
+        if ($oldestMessage && ($oldestMessage + ($minutes * 60)) < time()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function scheduledTaskFailed(): bool
+    {
+        $minutes = $this->configService->getInt(
+            'FroshTools.config.monitorTaskGraceTime');
+
+        $date = new \DateTime();
+        $date->modify(sprintf('-%d minutes', $minutes));
+
+        $criteria = new Criteria();
+        $criteria->addFilter(
+            new RangeFilter(
+                'nextExecutionTime',
+                ['lte' => $date->format(\DATE_ATOM)]
+            )
+        );
+        $criteria->addFilter(new NotFilter(
+            NotFilter::CONNECTION_AND,
+            [
+                new EqualsFilter('status', ScheduledTaskDefinition::STATUS_INACTIVE),
+            ]
+        ));
+
+        $oldTasks = $this->scheduledTaskRepository
+            ->searchIds($criteria, Context::createDefaultContext())->getIds();
+
+        if (count($oldTasks) === 0) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Components/Elasticsearch/EsProductDefinition.php
+++ b/src/Components/Elasticsearch/EsProductDefinition.php
@@ -39,7 +39,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Elasticsearch\Framework\AbstractElasticsearchDefinition;
 use function sprintf;
 use function str_replace;
-use function substr;
 
 class EsProductDefinition extends AbstractElasticsearchDefinition
 {
@@ -239,7 +238,7 @@ class EsProductDefinition extends AbstractElasticsearchDefinition
             }
         }
 
-        return substr($coalesce, 0, -1) . ')';
+        return mb_substr($coalesce, 0, -1) . ')';
     }
 
     private function getTranslationQuery(array $fields, Context $context): QueryBuilder

--- a/src/Components/Messenger/TaskLoggingMiddleware.php
+++ b/src/Components/Messenger/TaskLoggingMiddleware.php
@@ -61,7 +61,7 @@ class TaskLoggingMiddleware implements MiddlewareInterface
         $taskName = end($classParts);
 
         if (str_ends_with($taskName, 'Message')) {
-            $taskName = substr($taskName, 0, -7);
+            $taskName = mb_substr($taskName, 0, -7);
         }
 
         return $taskName;

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/master/src/Core/System/SystemConfig/Schema/config.xsd">
+
+    <card>
+        <title>Monitoring</title>
+        <title lang="de-DE">Überwachung</title>
+
+        <input-field type="text">
+            <name>monitorMail</name>
+            <label>Monitor mail address</label>
+            <label lang="de-DE">Überwachungsmailadresse</label>
+            <helpText>This email address is used when you use the CLI command frosh:monitor</helpText>
+            <helpText lang="de-DE">Diese Mailadresse wird beim Aufruf vom CLI Kommando frosh:monitor genutzt</helpText>
+        </input-field>
+
+        <input-field type="int">
+            <name>monitorQueueGraceTime</name>
+            <label>Scheduled task grace time</label>
+            <label lang="de-DE">Geplante Karenzzeit der Queue</label>
+            <helpText>After X minutes a queue is considered stuck / faulty</helpText>
+            <helpText lang="de-DE">Nach X Minuten gilt eine Queue als festgefahren / fehlerhaft</helpText>
+            <defaultValue>15</defaultValue>
+        </input-field>
+
+        <input-field type="int">
+            <name>monitorTaskGraceTime</name>
+            <label>Scheduled task grace time</label>
+            <label lang="de-DE">Geplante Karenzzeit der Aufgabe</label>
+            <helpText>After X minutes a scheudled task is considered stuck / faulty</helpText>
+            <helpText lang="de-DE">Nach X Minuten gilt eine geplante Aufgabe als festgefahren / fehlerhaft</helpText>
+            <defaultValue>10</defaultValue>
+        </input-field>
+    </card>
+
+</config>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,6 +5,14 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="Frosh\Tools\Command\MonitorCommand">
+            <argument type="service" id="Shopware\Core\Content\Mail\Service\MailService"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="scheduled_task.repository"/>
+            <tag name="console.command"/>
+        </service>
+
         <service id="Frosh\Tools\Command\ChangeUserPasswordCommand">
             <argument type="service" id="user.repository"/>
             <tag name="console.command"/>


### PR DESCRIPTION
As talked about with @shyim in Slack here is a simple integration with email instead of webhooks.

The integration with the notifier component from symfony is nice as well, but uses the message queue to send messages. There is always the possibility of adding an own webhook interface, but probably just overkill atm (as well as adding an own mailtemplate/migration etc. to the mail integration).

Feel free to mention the other dev that you referred to.


**Usage**

3 configs are added

- Mail
- Grace time for queue (those are curerntly fixed in the code of the healthchecker)
- Grace time for task (those are curerntly fixed in the code of the healthchecker)


**First argument must be a Saleschannel ID**

`bin/console frosh:monitor 4606300361c34ae3b69d813bb292f823`

**Email can be overwritten in command:**

bin/console frosh:monitor 4606300361c34ae3b69d813bb292f823 --email=michahobert@test.de


**PS**: Small fixes done by PHPCSFIXER