### PR TITLE
Visual Queue-Tab update

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/index.js
@@ -2,7 +2,6 @@ import template from './template.twig';
 import './style.scss';
 
 const { Component, Mixin } = Shopware;
-const { Criteria } = Shopware.Data;
 
 Component.register('frosh-tools-tab-queue', {
     template,
@@ -60,7 +59,7 @@ Component.register('frosh-tools-tab-queue', {
             this.showResetModal = false;
             this.createdComponent();
             this.createNotificationSuccess({
-                message: 'The queue has been cleared'
+                message: this.$tc('frosh-tools.tabs.queue.reset.success')
             })
             this.isLoading = false;
         }

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/style.scss
@@ -1,4 +1,9 @@
 .frosh-tools-tab-queue__manager-card {
+    .sw-card__toolbar {
+        display: flex;
+        justify-content: space-between;
+    }
+
     .sw-card__content {
         padding: 0;
     }

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/template.twig
@@ -1,28 +1,25 @@
 <sw-card-view>
     <sw-card class="frosh-tools-tab-queue__manager-card" :title="$tc('frosh-tools.tabs.queue.title')" :isLoading="isLoading" :large="true">
         <template #toolbar>
-            <!-- @todo: Make the refresh button fancy -->
             <sw-button variant="ghost" @click="refresh"><sw-icon :small="true" name="default-arrow-360-left"></sw-icon></sw-button>
+            <sw-button variant="danger" @click="showResetModal = true">{{ $tc('frosh-tools.resetQueue') }}</sw-button>
         </template>
 
         <sw-data-grid
             :showSelection="false"
             :dataSource="queueEntries"
             :columns="columns"
+            :showActions="false"
         >
         </sw-data-grid>
     </sw-card>
 
-    <sw-card class="frosh-tools-tab-queue__action-card" title="Actions" :large="true">
-        <sw-button variant="danger" @click="showResetModal = true">{{ $tc('frosh-tools.resetQueue') }}</sw-button>
-    </sw-card>
-
-    <sw-modal v-if="showResetModal" title="Reset Queue" variant="small" @modal-close="showResetModal = false">
-        Resetting Queue will remove all outgoing tasks.
+    <sw-modal v-if="showResetModal" :title="$tc('frosh-tools.tabs.queue.reset.modal.title')" variant="small" @modal-close="showResetModal = false">
+        {{ $tc('frosh-tools.tabs.queue.reset.modal.description') }}
 
         <template #modal-footer>
-            <sw-button @click="showResetModal = false">Cancel</sw-button>
-            <sw-button variant="danger" @click="resetQueue">Reset</sw-button>
+            <sw-button @click="showResetModal = false">{{ $tc('global.default.cancel') }}</sw-button>
+            <sw-button variant="danger" @click="resetQueue">{{ $tc('frosh-tools.tabs.queue.reset.modal.reset') }}</sw-button>
         </template>
     </sw-modal>
 </sw-card-view>

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -16,7 +16,15 @@
         "title": "Geplante Aufgaben"
       },
       "queue": {
-        "title": "Warteschlange"
+        "title": "Warteschlange",
+        "reset": {
+          "modal": {
+            "title": "Warteschlange zurücksetzen",
+            "description": "Durch das Zurücksetzen der Warteschlange werden alle ausgehenden Aufgaben entfernt.",
+            "reset": "Zurücksetzen"
+          },
+          "success": "Die Warteschlange wurde geleert"
+        }
       },
       "elasticsearch": {
         "title": "Elasticsearch"
@@ -133,7 +141,7 @@
     "size": "Größe",
     "docs": "Dokumente",
     "delete": "Löschen",
-    "resetQueue": "Queue zurücksetzen",
+    "resetQueue": "Warteschlange zurücksetzen",
     "date": "Zeitpunkt",
     "channel": "Kanal",
     "level": "Level",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -16,7 +16,15 @@
         "title": "Scheduled Tasks Manager"
       },
       "queue": {
-        "title": "Queue Manager"
+        "title": "Queue Manager",
+        "reset": {
+          "modal": {
+            "title": "Reset Queue",
+            "description": "Resetting Queue will remove all outgoing tasks.",
+            "reset": "Reset"
+          },
+          "success": "The queue has been cleared"
+        }
       },
       "elasticsearch": {
         "title": "Elasticsearch Manager"


### PR DESCRIPTION
- Make refresh fancy again
- Moved reset action button to grid header like in scheduled tasks
- Added snippets
- Removed empty grid actions column

Before:

![image](https://user-images.githubusercontent.com/28557712/195820537-b9a738e4-a033-4521-b557-4cbb57dc7ad6.png)

After:

![image](https://user-images.githubusercontent.com/28557712/195819944-bdc18341-d378-403c-b643-9fa696d4a1a5.png)


<a href="https://gitpod.io/#https://github.com/FriendsOfShopware/FroshTools/pull/136"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

