### PR TITLE
Add ACL to FroshTool

### DIFF
--- a/src/Controller/CacheController.php
+++ b/src/Controller/CacheController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 class CacheController
 {
@@ -23,7 +23,7 @@ class CacheController
     }
 
     /**
-     * @Route(path="/cache", methods={"GET"}, name="api.frosh.tools.cache.get")
+     * @Route(path="/cache", methods={"GET"}, name="api.frosh.tools.cache.get", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function cacheStatistics(): JsonResponse
     {
@@ -70,7 +70,7 @@ class CacheController
     }
 
     /**
-     * @Route(path="/cache/{folder}", methods={"DELETE"}, name="api.frosh.tools.cache.clear")
+     * @Route(path="/cache/{folder}", methods={"DELETE"}, name="api.frosh.tools.cache.clear", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function clearCache(string $folder): JsonResponse
     {

--- a/src/Controller/CacheController.php
+++ b/src/Controller/CacheController.php
@@ -23,7 +23,7 @@ class CacheController
     }
 
     /**
-     * @Route(path="/cache", methods={"GET"}, name="api.frosh.tools.cache.get", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/cache", methods={"GET"}, name="api.frosh.tools.cache.get")
      */
     public function cacheStatistics(): JsonResponse
     {
@@ -70,7 +70,7 @@ class CacheController
     }
 
     /**
-     * @Route(path="/cache/{folder}", methods={"DELETE"}, name="api.frosh.tools.cache.clear", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/cache/{folder}", methods={"DELETE"}, name="api.frosh.tools.cache.clear")
      */
     public function clearCache(string $folder): JsonResponse
     {

--- a/src/Controller/ElasticsearchController.php
+++ b/src/Controller/ElasticsearchController.php
@@ -21,7 +21,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/status", methods={"GET"}, name="api.frosh.tools.elasticsearch.status", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/status", methods={"GET"}, name="api.frosh.tools.elasticsearch.status")
      */
     public function status(): Response
     {
@@ -33,7 +33,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/indices", methods={"GET"}, name="api.frosh.tools.elasticsearch.indices", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/indices", methods={"GET"}, name="api.frosh.tools.elasticsearch.indices")
      */
     public function indices(): Response
     {
@@ -45,7 +45,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/index/{indexName}", methods={"DELETE"}, name="api.frosh.tools.elasticsearch.delete_index", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/index/{indexName}", methods={"DELETE"}, name="api.frosh.tools.elasticsearch.delete_index")
      */
     public function deleteIndex(string $indexName): Response
     {
@@ -57,7 +57,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/console/{path}", name="api.frosh.tools.elasticsearch.proxy", requirements={"path" = ".*"}, defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/console/{path}", name="api.frosh.tools.elasticsearch.proxy", requirements={"path" = ".*"})
      */
     public function console(Request $request, string $path): Response
     {
@@ -71,7 +71,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/flush_all", methods={"POST"}, name="api.frosh.tools.elasticsearch.flush", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/flush_all", methods={"POST"}, name="api.frosh.tools.elasticsearch.flush")
      */
     public function flushAll(): Response
     {
@@ -81,7 +81,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/reindex", methods={"POST"}, name="api.frosh.tools.elasticsearch.reindex", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/reindex", methods={"POST"}, name="api.frosh.tools.elasticsearch.reindex")
      */
     public function reindex(): Response
     {
@@ -91,7 +91,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/switch_alias", methods={"POST"}, name="api.frosh.tools.elasticsearch.switch_alias", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/switch_alias", methods={"POST"}, name="api.frosh.tools.elasticsearch.switch_alias")
      */
     public function switchAlias(): Response
     {
@@ -101,7 +101,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/cleanup", methods={"POST"}, name="api.frosh.tools.elasticsearch.cleanup", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/cleanup", methods={"POST"}, name="api.frosh.tools.elasticsearch.cleanup")
      */
     public function deleteUnusedIndices(): Response
     {
@@ -111,7 +111,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/reset", methods={"POST"}, name="api.frosh.tools.elasticsearch.reset", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/reset", methods={"POST"}, name="api.frosh.tools.elasticsearch.reset")
      */
     public function reset(): Response
     {

--- a/src/Controller/ElasticsearchController.php
+++ b/src/Controller/ElasticsearchController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools/elasticsearch", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools/elasticsearch", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 class ElasticsearchController
 {
@@ -21,7 +21,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/status", methods={"GET"}, name="api.frosh.tools.elasticsearch.status")
+     * @Route(path="/status", methods={"GET"}, name="api.frosh.tools.elasticsearch.status", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function status(): Response
     {
@@ -33,7 +33,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/indices", methods={"GET"}, name="api.frosh.tools.elasticsearch.indices")
+     * @Route(path="/indices", methods={"GET"}, name="api.frosh.tools.elasticsearch.indices", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function indices(): Response
     {
@@ -45,7 +45,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/index/{indexName}", methods={"DELETE"}, name="api.frosh.tools.elasticsearch.delete_index")
+     * @Route(path="/index/{indexName}", methods={"DELETE"}, name="api.frosh.tools.elasticsearch.delete_index", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function deleteIndex(string $indexName): Response
     {
@@ -57,7 +57,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/console/{path}", name="api.frosh.tools.elasticsearch.proxy", requirements={"path" = ".*"})
+     * @Route(path="/console/{path}", name="api.frosh.tools.elasticsearch.proxy", requirements={"path" = ".*"}, defaults={"_acl"={"frosh_tools:read"}})
      */
     public function console(Request $request, string $path): Response
     {
@@ -71,7 +71,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/flush_all", methods={"POST"}, name="api.frosh.tools.elasticsearch.flush")
+     * @Route(path="/flush_all", methods={"POST"}, name="api.frosh.tools.elasticsearch.flush", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function flushAll(): Response
     {
@@ -81,7 +81,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/reindex", methods={"POST"}, name="api.frosh.tools.elasticsearch.reindex")
+     * @Route(path="/reindex", methods={"POST"}, name="api.frosh.tools.elasticsearch.reindex", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function reindex(): Response
     {
@@ -91,7 +91,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/switch_alias", methods={"POST"}, name="api.frosh.tools.elasticsearch.switch_alias")
+     * @Route(path="/switch_alias", methods={"POST"}, name="api.frosh.tools.elasticsearch.switch_alias", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function switchAlias(): Response
     {
@@ -101,7 +101,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/cleanup", methods={"POST"}, name="api.frosh.tools.elasticsearch.cleanup")
+     * @Route(path="/cleanup", methods={"POST"}, name="api.frosh.tools.elasticsearch.cleanup", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function deleteUnusedIndices(): Response
     {
@@ -111,7 +111,7 @@ class ElasticsearchController
     }
 
     /**
-     * @Route(path="/reset", methods={"POST"}, name="api.frosh.tools.elasticsearch.reset")
+     * @Route(path="/reset", methods={"POST"}, name="api.frosh.tools.elasticsearch.reset", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function reset(): Response
     {

--- a/src/Controller/FeatureFlagController.php
+++ b/src/Controller/FeatureFlagController.php
@@ -25,7 +25,7 @@ class FeatureFlagController
     }
 
     /**
-     * @Route(path="/feature-flag/list", methods={"GET"}, name="api.frosh.tools.feature-flag.list", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/feature-flag/list", methods={"GET"}, name="api.frosh.tools.feature-flag.list")
      */
     public function list(): JsonResponse
     {
@@ -46,7 +46,7 @@ class FeatureFlagController
     }
 
     /**
-     * @Route(path="/feature-flag/toggle", methods={"POST"}, name="api.frosh.tools.feature-flag.toggle", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/feature-flag/toggle", methods={"POST"}, name="api.frosh.tools.feature-flag.toggle")
      */
     public function toggle(Request $request): Response
     {

--- a/src/Controller/FeatureFlagController.php
+++ b/src/Controller/FeatureFlagController.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 class FeatureFlagController
 {
@@ -25,7 +25,7 @@ class FeatureFlagController
     }
 
     /**
-     * @Route(path="/feature-flag/list", methods={"GET"}, name="api.frosh.tools.feature-flag.list")
+     * @Route(path="/feature-flag/list", methods={"GET"}, name="api.frosh.tools.feature-flag.list", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function list(): JsonResponse
     {
@@ -46,7 +46,7 @@ class FeatureFlagController
     }
 
     /**
-     * @Route(path="/feature-flag/toggle", methods={"POST"}, name="api.frosh.tools.feature-flag.toggle")
+     * @Route(path="/feature-flag/toggle", methods={"POST"}, name="api.frosh.tools.feature-flag.toggle", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function toggle(Request $request): Response
     {

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 class HealthController
 {
@@ -26,7 +26,7 @@ class HealthController
     }
 
     /**
-     * @Route(path="/health/status", methods={"GET"}, name="api.frosh.tools.health.status")
+     * @Route(path="/health/status", methods={"GET"}, name="api.frosh.tools.health.status", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function status(): JsonResponse
     {
@@ -39,7 +39,7 @@ class HealthController
     }
 
     /**
-     * @Route(path="/performance/status", methods={"GET"}, name="api.frosh.tools.performance.status")
+     * @Route(path="/performance/status", methods={"GET"}, name="api.frosh.tools.performance.status", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function performanceStatus(): JsonResponse
     {

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -26,7 +26,7 @@ class HealthController
     }
 
     /**
-     * @Route(path="/health/status", methods={"GET"}, name="api.frosh.tools.health.status", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/health/status", methods={"GET"}, name="api.frosh.tools.health.status")
      */
     public function status(): JsonResponse
     {
@@ -39,7 +39,7 @@ class HealthController
     }
 
     /**
-     * @Route(path="/performance/status", methods={"GET"}, name="api.frosh.tools.performance.status", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/performance/status", methods={"GET"}, name="api.frosh.tools.performance.status")
      */
     public function performanceStatus(): JsonResponse
     {

--- a/src/Controller/LogController.php
+++ b/src/Controller/LogController.php
@@ -27,7 +27,7 @@ class LogController
     }
 
     /**
-     * @Route(path="/logs/files", methods={"GET"}, name="api.frosh.tools.logs.files", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/logs/files", methods={"GET"}, name="api.frosh.tools.logs.files")
      */
     public function getLogFiles(): JsonResponse
     {
@@ -35,7 +35,7 @@ class LogController
     }
 
     /**
-     * @Route(path="/logs/file", methods={"GET"}, name="api.frosh.tools.logs.file-listing", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/logs/file", methods={"GET"}, name="api.frosh.tools.logs.file-listing")
      */
     public function getLog(Request $request): Response
     {

--- a/src/Controller/LogController.php
+++ b/src/Controller/LogController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 class LogController
 {
@@ -27,7 +27,7 @@ class LogController
     }
 
     /**
-     * @Route(path="/logs/files", methods={"GET"}, name="api.frosh.tools.logs.files")
+     * @Route(path="/logs/files", methods={"GET"}, name="api.frosh.tools.logs.files", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function getLogFiles(): JsonResponse
     {
@@ -35,7 +35,7 @@ class LogController
     }
 
     /**
-     * @Route(path="/logs/file", methods={"GET"}, name="api.frosh.tools.logs.file-listing")
+     * @Route(path="/logs/file", methods={"GET"}, name="api.frosh.tools.logs.file-listing", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function getLog(Request $request): Response
     {

--- a/src/Controller/QueueController.php
+++ b/src/Controller/QueueController.php
@@ -22,7 +22,7 @@ class QueueController
     }
 
     /**
-     * @Route(path="/queue/list", methods={"GET"}, name="api.frosh.tools.queue.list", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/queue/list", methods={"GET"}, name="api.frosh.tools.queue.list")
      */
     public function list(): JsonResponse
     {
@@ -39,7 +39,7 @@ class QueueController
     }
 
     /**
-     * @Route(path="/queue", methods={"DELETE"}, name="api.frosh.tools.queue.clear", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/queue", methods={"DELETE"}, name="api.frosh.tools.queue.clear")
      */
     public function resetQueue(): JsonResponse
     {

--- a/src/Controller/QueueController.php
+++ b/src/Controller/QueueController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 class QueueController
 {
@@ -22,7 +22,7 @@ class QueueController
     }
 
     /**
-     * @Route(path="/queue/list", methods={"GET"}, name="api.frosh.tools.queue.list")
+     * @Route(path="/queue/list", methods={"GET"}, name="api.frosh.tools.queue.list", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function list(): JsonResponse
     {
@@ -39,7 +39,7 @@ class QueueController
     }
 
     /**
-     * @Route(path="/queue", methods={"DELETE"}, name="api.frosh.tools.queue.clear")
+     * @Route(path="/queue", methods={"DELETE"}, name="api.frosh.tools.queue.clear", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function resetQueue(): JsonResponse
     {

--- a/src/Controller/ScheduledTaskController.php
+++ b/src/Controller/ScheduledTaskController.php
@@ -37,7 +37,7 @@ class ScheduledTaskController
     }
 
     /**
-     * @Route(path="/scheduled-task/{id}", methods={"POST"}, name="api.frosh.tools.scheduled.task.run", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/scheduled-task/{id}", methods={"POST"}, name="api.frosh.tools.scheduled.task.run")
      */
     public function runTask(string $id, Context $context): JsonResponse
     {
@@ -76,7 +76,7 @@ class ScheduledTaskController
     }
 
     /**
-     * @Route(path="/scheduled-tasks/register", methods={"POST"}, name="api.frosh.tools.scheduled.tasks.register", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/scheduled-tasks/register", methods={"POST"}, name="api.frosh.tools.scheduled.tasks.register")
      */
     public function registerTasks(): JsonResponse
     {

--- a/src/Controller/ScheduledTaskController.php
+++ b/src/Controller/ScheduledTaskController.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 class ScheduledTaskController
 {
@@ -37,7 +37,7 @@ class ScheduledTaskController
     }
 
     /**
-     * @Route(path="/scheduled-task/{id}", methods={"POST"}, name="api.frosh.tools.scheduled.task.run")
+     * @Route(path="/scheduled-task/{id}", methods={"POST"}, name="api.frosh.tools.scheduled.task.run", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function runTask(string $id, Context $context): JsonResponse
     {
@@ -76,7 +76,7 @@ class ScheduledTaskController
     }
 
     /**
-     * @Route(path="/scheduled-tasks/register", methods={"POST"}, name="api.frosh.tools.scheduled.tasks.register")
+     * @Route(path="/scheduled-tasks/register", methods={"POST"}, name="api.frosh.tools.scheduled.tasks.register", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function registerTasks(): JsonResponse
     {

--- a/src/Controller/ShopwareFilesController.php
+++ b/src/Controller/ShopwareFilesController.php
@@ -30,7 +30,7 @@ class ShopwareFilesController
     }
 
     /**
-     * @Route(path="/shopware-files", methods={"GET"}, name="api.frosh.tools.shopware-files", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/shopware-files", methods={"GET"}, name="api.frosh.tools.shopware-files")
      */
     public function listShopwareFiles(): JsonResponse
     {
@@ -89,7 +89,7 @@ class ShopwareFilesController
     }
 
     /**
-     * @Route(path="/file-contents", methods={"GET"}, name="api.frosh.tools.file-contents", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/file-contents", methods={"GET"}, name="api.frosh.tools.file-contents")
      */
     public function getFileContents(Request $request): JsonResponse
     {
@@ -120,7 +120,7 @@ class ShopwareFilesController
     }
 
     /**
-     * @Route(path="/shopware-file/restore", methods={"GET"}, name="api.frosh.tools.shopware-file.restore", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/shopware-file/restore", methods={"GET"}, name="api.frosh.tools.shopware-file.restore")
      */
     public function restoreShopwareFile(Request $request): JsonResponse
     {

--- a/src/Controller/ShopwareFilesController.php
+++ b/src/Controller/ShopwareFilesController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 class ShopwareFilesController
 {
@@ -30,7 +30,7 @@ class ShopwareFilesController
     }
 
     /**
-     * @Route(path="/shopware-files", methods={"GET"}, name="api.frosh.tools.shopware-files")
+     * @Route(path="/shopware-files", methods={"GET"}, name="api.frosh.tools.shopware-files", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function listShopwareFiles(): JsonResponse
     {
@@ -89,7 +89,7 @@ class ShopwareFilesController
     }
 
     /**
-     * @Route(path="/file-contents", methods={"GET"}, name="api.frosh.tools.file-contents")
+     * @Route(path="/file-contents", methods={"GET"}, name="api.frosh.tools.file-contents", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function getFileContents(Request $request): JsonResponse
     {
@@ -120,7 +120,7 @@ class ShopwareFilesController
     }
 
     /**
-     * @Route(path="/shopware-file/restore", methods={"GET"}, name="api.frosh.tools.shopware-file.restore")
+     * @Route(path="/shopware-file/restore", methods={"GET"}, name="api.frosh.tools.shopware-file.restore", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function restoreShopwareFile(Request $request): JsonResponse
     {

--- a/src/Controller/StateMachineController.php
+++ b/src/Controller/StateMachineController.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}})
+ * @Route(path="/api/_action/frosh-tools", defaults={"_routeScope"={"api"}, "_acl"={"frosh_tools:read"}})
  */
 final class StateMachineController
 {
@@ -27,7 +27,7 @@ final class StateMachineController
     }
 
     /**
-     * @Route(path="/state-machines/load", methods={"GET"}, name="api.frosh.tools.state-machines.load")
+     * @Route(path="/state-machines/load", methods={"GET"}, name="api.frosh.tools.state-machines.load", defaults={"_acl"={"frosh_tools:read"}})
      */
     public function load(Request $request): JsonResponse
     {

--- a/src/Controller/StateMachineController.php
+++ b/src/Controller/StateMachineController.php
@@ -27,7 +27,7 @@ final class StateMachineController
     }
 
     /**
-     * @Route(path="/state-machines/load", methods={"GET"}, name="api.frosh.tools.state-machines.load", defaults={"_acl"={"frosh_tools:read"}})
+     * @Route(path="/state-machines/load", methods={"GET"}, name="api.frosh.tools.state-machines.load")
      */
     public function load(Request $request): JsonResponse
     {

--- a/src/Resources/app/administration/src/module/frosh-tools/acl/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/acl/index.js
@@ -1,0 +1,14 @@
+Shopware.Service('privileges')
+    .addPrivilegeMappingEntry({
+        category: 'additional_permissions',
+        parent: null,
+        key: 'frosh_tools',
+        roles: {
+            frosh_tools: {
+                privileges: [
+                    'frosh_tools:read',
+                ],
+                dependencies: [],
+            },
+        },
+    });

--- a/src/Resources/app/administration/src/module/frosh-tools/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/index.js
@@ -8,6 +8,7 @@ import './component/frosh-tools-tab-files';
 import './component/frosh-tools-tab-feature-flags';
 import './component/frosh-tools-tab-state-machines';
 import './page/index';
+import './acl'
 
 Shopware.Module.register('frosh-tools', {
     type: 'plugin',
@@ -27,63 +28,72 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-index',
                     path: 'index',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
                 cache: {
                     component: 'frosh-tools-tab-cache',
                     path: 'cache',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
                 queue: {
                     component: 'frosh-tools-tab-queue',
                     path: 'queue',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
                 scheduled: {
                     component: 'frosh-tools-tab-scheduled',
                     path: 'scheduled',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
                 elasticsearch: {
                     component: 'frosh-tools-tab-elasticsearch',
                     path: 'elasticsearch',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
                 logs: {
                     component: 'frosh-tools-tab-logs',
                     path: 'logs',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
                 files: {
                     component: 'frosh-tools-tab-files',
                     path: 'files',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
                 featureflags: {
                     component: 'frosh-tools-tab-feature-flags',
                     path: 'feature-flags',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
                 statemachines: {
                     component: 'frosh-tools-tab-state-machines',
                     path: 'state-machines',
                     meta: {
-                        parentPath: 'frosh.tools.index'
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index'
                     }
                 },
             }

--- a/src/Resources/app/administration/src/module/frosh-tools/page/index/frosh-tools.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/page/index/frosh-tools.scss
@@ -14,6 +14,6 @@
     }
 }
 
-.sw-version__status {
+.sw-version__status.has-permission {
     cursor: pointer;
 }

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -103,5 +103,13 @@
     "order": "Bestellung",
     "transaction": "Bezahlung",
     "delivery": "Versand"
-  }
+  },
+    "sw-privileges": {
+        "additional_permissions": {
+            "frosh_tools": {
+                "frosh_tools": "Überwachung anzeigen",
+                "label": "Frosh tools"
+            }
+        }
+    }
 }

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -103,5 +103,13 @@
     "order": "Order",
     "transaction": "Payment",
     "delivery": "Delivery"
-  }
+  },
+    "sw-privileges": {
+        "additional_permissions": {
+            "frosh_tools": {
+                "frosh_tools": "View monitoring",
+                "label": "Frosh tools"
+            }
+        }
+    }
 }

--- a/src/Resources/app/administration/src/overrides/sw-version/index.js
+++ b/src/Resources/app/administration/src/overrides/sw-version/index.js
@@ -4,15 +4,17 @@ const { Component } = Shopware;
 
 Component.override('sw-version', {
     template,
-    inject: ['froshToolsService'],
+    inject: ['froshToolsService', 'acl'],
 
     async created() {
+        this.checkPermission();
         await this.checkHealth();
     },
 
     data() {
         return {
-            health: null
+            health: null,
+            hasPermission: false
         }
     },
 
@@ -63,6 +65,10 @@ Component.override('sw-version', {
             setInterval(async() => {
                 this.health = await this.froshToolsService.healthStatus();
             }, 30000);
+        },
+
+         checkPermission() {
+            this.hasPermission = this.acl.can('frosh_tools:read');
         }
     }
 })

--- a/src/Resources/app/administration/src/overrides/sw-version/template.twig
+++ b/src/Resources/app/administration/src/overrides/sw-version/template.twig
@@ -1,14 +1,21 @@
 {% block sw_version_status %}
     <router-link
+        v-if="hasPermission"
         :to="{ name: 'frosh.tools.index.index' }"
-        class="sw-version__status"
+        class="sw-version__status has-permission"
         v-tooltip="{
             showDelay: 300,
             message: healthPlaceholder
         }"
     >
         {% block sw_version_status_badge %}
-            <sw-color-badge v-if="health" :variant="healthVariant" :rounded="true"></sw-color-badge>
+            <sw-color-badge v-if="health && hasPermission" :variant="healthVariant" :rounded="true"></sw-color-badge>
+            <template  v-else>
+                {% parent %}
+            </template>
         {% endblock %}
     </router-link>
+    <template  v-else>
+        {% parent %}
+    </template>
 {% endblock %}


### PR DESCRIPTION
I have added an ACL where the users need to have permissions to acces the FroshTool monitoring. This way, not every user in the administration can access the monitoring.

When the user does not have these permissions, they will not have acces to the individual pages from the FroshTool monitoring and they will not have the custom health badge.

I also fixed a small bug where the the back button would not send you to the index page. This was due to the parentPath being 'frosh.tools.index' instead of 'frosh.tools.index.index'

<a href="https://gitpod.io/#https://github.com/FriendsOfShopware/FroshTools/pull/141"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

