### PR TITLE
Update de-DE.json

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -37,7 +37,7 @@
       },
       "files": {
         "title": "Shopware Dateien Checker",
-        "allFilesOk": "Alle Dateien wurden nicht manipuliert",
+        "allFilesOk": "Alle Dateien entsprechen den Originalen, es wurden keine Manipulationen erkannt",
         "notOk": "Es gibt Dateien, die manipuliert wurden",
         "openOriginal": "Öffne Originaldatei auf github",
         "restore": {


### PR DESCRIPTION
German translation for "allFilesOK" is odd for native speakers, in english similar to "all files are manipulated not" Now it reads in english "All files correspond to the originals, no manipulations were detected"

<a href="https://gitpod.io/#https://github.com/FriendsOfShopware/FroshTools/pull/155"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

