### PR TITLE
fix: error on unlimited max_execution_time

### DIFF
--- a/src/Components/Health/Checker/HealthChecker/PhpChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/PhpChecker.php
@@ -63,7 +63,7 @@ class PhpChecker implements CheckerInterface
     {
         $minMaxExecutionTime = 30;
         $currentMaxExecutionTime = (int) \ini_get('max_execution_time');
-        if ($currentMaxExecutionTime < $minMaxExecutionTime) {
+        if ($currentMaxExecutionTime < $minMaxExecutionTime && $currentMaxExecutionTime != 0) {
             $collection->add(
                 SettingsResult::error(
                     'php-max-execution',


### PR DESCRIPTION
There should not be a warning when max_execution_time is set to 0