### PR TITLE
fix(EsChecker): updated link

### DIFF
--- a/src/Components/Health/Checker/PerformanceChecker/EsChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/EsChecker.php
@@ -25,7 +25,7 @@ class EsChecker implements CheckerInterface
                     'Elasticsearch is disabled',
                     'disabled',
                     'enabled',
-                    'https://developer.shopware.com/docs/guides/hosting/infrastructure/infrastructure/elasticsearch-setup'
+                    'https://developer.shopware.com/docs/guides/hosting/infrastructure/elasticsearch/elasticsearch-setup'
                 )
             );
 


### PR DESCRIPTION
Hey guys,

while using your plugin, I noticed that the link to the Elasticsearch-Setup is not up-to-date anymore. 

I fixed this tiny bug in my pull request. Hope it helps :) 