### PR TITLE
Turn command into lowercase

### DIFF
--- a/src/Command/EnvDelCommand.php
+++ b/src/Command/EnvDelCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand('frosh:env:Del', 'Delete environment variable')]
+#[AsCommand('frosh:env:del', 'Delete environment variable')]
 class EnvDelCommand extends Command
 {
     public function __construct(private readonly string $envPath)


### PR DESCRIPTION
Isn't it nicer to have `frosh:env:del` instead of `frosh:env:list`?