### PR TITLE
Fix spelling & formatting, add command to README.md

### DIFF
--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -13,7 +13,7 @@
 
 # 1.0.6
 
-- Simplify enviromment delete command name
+- Simplify environment delete command name
 - Simplify queue checker
 
 # 1.0.5

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ bin/console frosh:env:set VARIABLE VALUE
 bin/console frosh:env:del VARIABLE
 ```
 
-### `frosh:dev:robots-txt` - For testshops - add/change robots.txt to stop crawers
+### `frosh:dev:robots-txt` - For testshops - add/change robots.txt to stop crawlers
 
 ```bash
 bin/console frosh:dev:robots-txt
@@ -113,6 +113,11 @@ bin/console frosh:composer-plugin:update
 ### `frosh:user:change:password` - updates user password
 ```bash
 bin/console frosh:user:change:password <username> [<password>]
+```
+
+### `frosh:monitor` - Monitor your scheduled tasks and queue with this command and get notified via email.
+```bash
+bin/console frosh:monitor <sales-channel-id>
 ```
 
 ## Suppress files from being restorable in FileChecker

--- a/src/Command/DevRobotsTxtCommand.php
+++ b/src/Command/DevRobotsTxtCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-#[AsCommand('frosh:dev:robots-txt')]
+#[AsCommand('frosh:dev:robots-txt', 'For testshops - add/change robots.txt to stop crawlers')]
 class DevRobotsTxtCommand extends Command
 {
     public function __construct(
@@ -23,7 +23,6 @@ class DevRobotsTxtCommand extends Command
     protected function configure(): void
     {
         $this->addOption('remove', 'r', InputOption::VALUE_NONE, 'Return to original file - delete input from this command');
-        $this->setDescription('For testshops - add/change robots.txt to stop crawers');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-#[AsCommand('frosh:monitor', 'Monitor your scheduled task and queue with this command and get notified via email.')]
+#[AsCommand('frosh:monitor', 'Monitor your scheduled tasks and queue with this command and get notified via email.')]
 class MonitorCommand extends Command
 {
     private const MONITOR_EMAIL_OPTION = 'email';

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -4,7 +4,7 @@
     "tabs": {
       "index": {
         "title": "System-Status",
-        "performance": "Performance recommendations"
+        "performance": "Performance Empfehlungen"
       },
       "systemInfo": {
         "title": "System-Info"
@@ -96,12 +96,12 @@
     "transaction": "Bezahlung",
     "delivery": "Versand"
   },
-    "sw-privileges": {
-        "additional_permissions": {
-            "frosh_tools": {
-                "frosh_tools": "Überwachung anzeigen",
-                "label": "Frosh tools"
-            }
-        }
+  "sw-privileges": {
+    "additional_permissions": {
+      "frosh_tools": {
+        "frosh_tools": "Überwachung anzeigen",
+        "label": "Frosh tools"
+      }
     }
+  }
 }

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -4,7 +4,7 @@
     "tabs": {
       "index": {
         "title": "System Status",
-        "performance": "Performance Empfehlungen"
+        "performance": "Performance recommendations"
       },
       "systemInfo": {
         "title": "System Info"
@@ -96,12 +96,12 @@
     "transaction": "Payment",
     "delivery": "Delivery"
   },
-    "sw-privileges": {
-        "additional_permissions": {
-            "frosh_tools": {
-                "frosh_tools": "View monitoring",
-                "label": "Frosh tools"
-            }
-        }
+  "sw-privileges": {
+    "additional_permissions": {
+      "frosh_tools": {
+        "frosh_tools": "View monitoring",
+        "label": "Frosh tools"
+      }
     }
+  }
 }

--- a/src/Resources/store/de.md
+++ b/src/Resources/store/de.md
@@ -14,7 +14,7 @@ Der aktuelle Funktionsumfang besteht aus:
     *   Zeigt die Einträge der Dateien /var/log/*.log an
 *   Task-Protokollierung
     *   Kann mit FROSH_TOOLS_TASK_LOGGING=1 in .env aktiviert werden. Dadurch wird ein Protokoll in var/log/task_logging-xx.log erstellt.
-        *   Mit FROSH_TOOLS_TASK_LOGGING_INFO=1 in .env werden alle Tasks gelogt.
+        *   Mit FROSH_TOOLS_TASK_LOGGING_INFO=1 in .env werden alle Tasks geloggt.
 *   Feature Flag Manager
     *   Erlaubt das aktivieren/deaktivieren von Feature Flags
 

--- a/src/Resources/store/en.md
+++ b/src/Resources/store/en.md
@@ -22,6 +22,6 @@ Link to repository: [https://github.com/FriendsOfShopware/FroshTools](https://g
 
 This plugin is part of [@FriendsOfShopware](https://store.shopware.com/en/friends-of-shopware.html).  
 
-Maintainer from the plugin is: [Soner Sayakci](https://github.com/shyim)
+Maintainer for the plugin is: [Soner Sayakci](https://github.com/shyim)
 
 For questions or bugs please create a [Github Issue](https://github.com/FriendsOfShopware/FroshTools/issues/new)


### PR DESCRIPTION
- Fix spelling in a number of files & swap snippet "frosh-tools.tabs.index.performance" between "de_DE" and "en_GB"
- Add missing command "frosh:monitor" to README.md
- Move description for command "frosh:dev:robots-txt" to AsCommand attribute