### PR TITLE
fix name/label in admin index.js module registration

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/index.js
@@ -96,7 +96,8 @@ Shopware.Module.register('frosh-tools', {
             group: 'plugins',
             to: 'frosh.tools.index.cache',
             icon: 'regular-cog',
-            name: 'frosh-tools.title'
+            name: 'frosh-tools',
+            label: 'frosh-tools.title'
         }
     ]
 });


### PR DESCRIPTION
The name will be displayed in the twig key parameter, label seems to be for translated names.
![frosh](https://github.com/FriendsOfShopware/FroshTools/assets/142704555/da44771a-b1b9-45c6-b4d5-42e00f551276)
