### PR TITLE
Add route, template and export

### DIFF
--- a/src/Components/StateMachines/Mermaid.php
+++ b/src/Components/StateMachines/Mermaid.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\StateMachines;
+
+use Shopware\Core\System\StateMachine\StateMachineEntity;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+final class Mermaid implements ExportInterface
+{
+    private const DEFAULT_PATH = __DIR__ . '/../../Resources/views/administration/mermaid';
+
+    private readonly Environment $twig;
+
+    public function __construct()
+    {
+        $path = realpath(self::DEFAULT_PATH);
+        if (!\is_string($path)) {
+            throw new \RuntimeException('Could not find default path for PlantUML templates');
+        }
+
+        $this->twig = new Environment(new FilesystemLoader($path));
+    }
+
+    public function export(StateMachineEntity $stateMachine, string $title = ''): string
+    {
+        return $this->twig->render('state-machine.html.twig', [
+            'title' => $title,
+            'initialState' => $stateMachine->getInitialState(),
+            'states' => $stateMachine->getStates()?->getElements(),
+            'transitions' => $stateMachine->getTransitions()?->getElements(),
+        ]);
+    }
+}

--- a/src/Resources/views/administration/mermaid/state-machine.html.twig
+++ b/src/Resources/views/administration/mermaid/state-machine.html.twig
@@ -1,0 +1,18 @@
+flowchart TD
+{{ 'START_STATE[Start state] -->' }} {{ initialState.getId() }}
+
+{% for state in states %}
+{{ state.getId() }}({{ state.getName()|replace({'(': "", ')': ""})  }})
+{% set temp %}{% apply spaceless %}
+{% for transition in transitions %}
+    {% if transition.getFromStateId() == state.getId() and transition.getActionName() != 'reopen' %}yes{% else %}{% endif %}
+{% endfor %}{% endapply %}
+{% endset %}
+{% if temp|trim is empty %}
+{{ state.getId() }} {{ '--> FINAL_STATE[Final state]' }}
+{% endif %}
+{% endfor %}
+
+{% for transition in transitions %}
+{{ transition.getFromStateId() }} {{ '--' }} {{ transition.getActionName() }} {{ '-->' }} {{ transition.getToStateId() }}
+{% endfor %}


### PR DESCRIPTION
Adds a API endpoint for getting mermaid flowcharts

GET {{url}}/api/_action/frosh-tools/state-machines/load-mermaid?stateMachine=order_transaction.state
GET {{url}}/api/_action/frosh-tools/state-machines/load-mermaid?stateMachine=order_delivery.state
GET {{url}}/api/_action/frosh-tools/state-machines/load-mermaid?stateMachine=order.state

Example response:

`{
  "data": "flowchart TD\nSTART_STATE[Start state] --> 0189e474ee557113994b4f678ba7574a\n\n0189e474ee557113994b4f678ba7574a(Open)\n0189e474ee557113994b4f678c711eb7(Cancelled)\n0189e474ee557113994b4f678c711eb7 --> FINAL_STATE[Final state]\n0189e474ee557113994b4f678d696964(Shipped)\n0189e474ee557113994b4f678db3c16c(Shipped partially)\n0189e474ee557113994b4f678e1eb368(Returned)\n0189e474ee557113994b4f678e1eb368 --> FINAL_STATE[Final state]\n0189e474ee557113994b4f678e75d0e0(Returned partially)\n\n0189e474ee557113994b4f678ba7574a -- ship --> 0189e474ee557113994b4f678d696964\n0189e474ee557113994b4f678ba7574a -- ship_partially --> 0189e474ee557113994b4f678db3c16c\n0189e474ee557113994b4f678ba7574a -- cancel --> 0189e474ee557113994b4f678c711eb7\n0189e474ee557113994b4f678d696964 -- retour --> 0189e474ee557113994b4f678e1eb368\n0189e474ee557113994b4f678d696964 -- retour_partially --> 0189e474ee557113994b4f678e75d0e0\n0189e474ee557113994b4f678d696964 -- cancel --> 0189e474ee557113994b4f678c711eb7\n0189e474ee557113994b4f678db3c16c -- retour --> 0189e474ee557113994b4f678e1eb368\n0189e474ee557113994b4f678db3c16c -- retour_partially --> 0189e474ee557113994b4f678e75d0e0\n0189e474ee557113994b4f678db3c16c -- ship --> 0189e474ee557113994b4f678d696964\n0189e474ee557113994b4f678db3c16c -- cancel --> 0189e474ee557113994b4f678c711eb7\n0189e474ee557113994b4f678c711eb7 -- reopen --> 0189e474ee557113994b4f678ba7574a\n0189e474ee557113994b4f678d696964 -- reopen --> 0189e474ee557113994b4f678ba7574a\n0189e474ee557113994b4f678db3c16c -- reopen --> 0189e474ee557113994b4f678ba7574a\n0189e474ee557113994b4f678e1eb368 -- reopen --> 0189e474ee557113994b4f678ba7574a\n0189e474ee557113994b4f678e75d0e0 -- reopen --> 0189e474ee557113994b4f678ba7574a\n0189e474ee557113994b4f678e75d0e0 -- retour --> 0189e474ee557113994b4f678e1eb368\n"
}`

![order](https://github.com/FriendsOfShopware/FroshTools/assets/8600299/68c1940f-1302-4ada-b816-17e5d1e37983)
![payment](https://github.com/FriendsOfShopware/FroshTools/assets/8600299/fc298165-6723-4d3f-b477-b8db60f8b80e)
![delivery](https://github.com/FriendsOfShopware/FroshTools/assets/8600299/e27d1313-cf13-4bf0-b26d-0ec39980d341)

