### PR TITLE
Add privileges to settings item

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/index.js
@@ -97,7 +97,8 @@ Shopware.Module.register('frosh-tools', {
             to: 'frosh.tools.index.cache',
             icon: 'regular-cog',
             name: 'frosh-tools',
-            label: 'frosh-tools.title'
+            label: 'frosh-tools.title',
+            privilege: 'frosh_tools:read'
         }
     ]
 });


### PR DESCRIPTION
Currently every user see this icon and the whole settings/extensions/tools navigation path.

![Screenshot 2023-10-19 at 09 33 50](https://github.com/FriendsOfShopware/FroshTools/assets/28557712/640605cf-9322-49c9-aacc-589f3df76413)

Now its gone

![Screenshot 2023-10-19 at 09 34 28](https://github.com/FriendsOfShopware/FroshTools/assets/28557712/7a6435e2-9257-40ab-8530-42429df52a97)
