### PR TITLE
Refactor the StateMachineViewer component

### DIFF
--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -178,14 +178,11 @@ class FroshTools extends ApiService {
         });
     }
 
-    stateMachines(stateMachine) {
-        const apiRoute = `${this.getApiBasePath()}/state-machines/load`;
+    stateMachines(id) {
+        const apiRoute = `${this.getApiBasePath()}/state-machines/load/${id}`;
         return this.httpClient.get(
             apiRoute,
             {
-                params: {
-                    stateMachine,
-                },
                 headers: this.getBasicHeaders()
             }
         ).then((response) => {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-state-machines/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-state-machines/index.js
@@ -16,6 +16,7 @@ Component.register('frosh-tools-tab-state-machines', {
 
     data() {
         return {
+            selectedStateMachine: null,
             image: null,
             isLoading: true,
         }
@@ -30,9 +31,14 @@ Component.register('frosh-tools-tab-state-machines', {
             this.isLoading = false;
         },
 
-        async onStateMachineChange(value) {
-            const response = (await this.froshToolsService.stateMachines(value));
-            const elem = document.getElementById('state_machine'); 
+        async onStateMachineChange(stateMachineChangeId) {
+            if (!stateMachineChangeId) {
+                return;
+            }
+
+            const response = await this.froshToolsService.stateMachines(stateMachineChangeId);
+
+            const elem = document.getElementById('state_machine');
             if ("svg" in response) {
                 this.image = response.svg;
                 elem.src = this.image;

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-state-machines/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-state-machines/style.scss
@@ -1,4 +1,23 @@
 .frosh-tools-tab-state-machines__state-machines-card {
+    .sw-card__toolbar {
+        .sw-select {
+            margin: 0;
+            display: flex;
+            flex-direction: row;
+            gap: 10px;
+            align-items: center;
+
+            .sw-field__label {
+                gap: 6px;
+                margin-bottom: 2px;
+            }
+
+            .sw-block-field__block {
+                flex: 1;
+            }
+        }
+    }
+
     .sw-card__content {
         padding: 0;
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-state-machines/template.html.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-state-machines/template.html.twig
@@ -1,10 +1,10 @@
 <sw-card-view>
     <sw-card
-            class="frosh-tools-tab-state-machines__state-machines-card"
-            :title="$tc('frosh-tools.tabs.state-machines.title')"
-            :isLoading="isLoading"
-            :large="true"
-            positionIdentifier="frosh-tools-tab-state-machines"
+        class="frosh-tools-tab-state-machines__state-machines-card"
+        :title="$tc('frosh-tools.tabs.state-machines.title')"
+        :isLoading="isLoading"
+        :large="true"
+        positionIdentifier="frosh-tools-tab-state-machines"
     >
 
         <div class="frosh-tools-tab-state-machines__state-machines-card-image-wrapper">
@@ -20,19 +20,15 @@
         </div>
 
         <template #toolbar>
-            <sw-select-field
-                    size="small"
-                    :aside="true"
-                    @change="onStateMachineChange"
-                    :label=" $tc('frosh-tools.tabs.state-machines.label')"
-                    :helpText="$tc('frosh-tools.tabs.state-machines.helpText')"
-            >
-                <option selected="selected" value="">{{ $tc('frosh-tools.chooseStateMachine') }}</option>
-                <option value="order.state">{{ $tc('frosh-tools.order') }}</option>
-                <option value="order_transaction.state">{{ $tc('frosh-tools.transaction') }}</option>
-                <option value="order_delivery.state">{{ $tc('frosh-tools.delivery') }}</option>
-            </sw-select-field>
+            <sw-entity-single-select
+                v-model="selectedStateMachine"
+                entity="state_machine"
+                :aside="true"
+                @change="onStateMachineChange"
+                :label="$tc('frosh-tools.tabs.state-machines.label')"
+                :placeholder="$tc('frosh-tools.chooseStateMachine')"
+                :helpText="$tc('frosh-tools.tabs.state-machines.helpText')"
+            />
         </template>
-
     </sw-card>
 </sw-card-view>


### PR DESCRIPTION
- Replaced `sw-select` with `sw-entity-single-select` to load all available StateMachines
- Changed Route to load stateMachine Plantuml image by `id` instead of `technicalName`
- Adjust view


New view:

![2023-10-31_21-50-47](https://github.com/FriendsOfShopware/FroshTools/assets/28557712/5b89ce7f-b433-45ae-a944-0fff2196fa2f)

![2023-10-31_21-50-41](https://github.com/FriendsOfShopware/FroshTools/assets/28557712/73708077-b6b2-4d4e-8012-ec0a4c0f12df)

