### PR TITLE
Fix message queue monitoring

### DIFF
--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -107,10 +107,9 @@ class MonitorCommand extends Command
 
     private function queueFailed(): bool
     {
-        /** @var string $createdAt */
-        $createdAt = $this->connection->fetchOne('SELECT IFNULL(MIN(created_at), 0) FROM messenger_messages');
-        $oldestMessage = (int) $createdAt;
-        $oldestMessage /= 10000;
+        /** @var string $availableAt */
+        $availableAt = $this->connection->fetchOne('SELECT IFNULL(MIN(available_at), 0) FROM messenger_messages');
+        $oldestMessage = (int) strtotime($availableAt);
         $minutes = $this->configService->getInt(
             'FroshTools.config.monitorQueueGraceTime'
         );

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -22,7 +22,7 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         $recommended = \sprintf('max %d mins', $maxDiff);
 
         /** @var string|false $oldestMessageAt */
-        $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages ORDER BY available_at ASC LIMIT 1');
+        $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages WHERE available_at < UTC_TIMESTAMP() ORDER BY available_at ASC LIMIT 1');
 
         if (\is_string($oldestMessageAt)) {
             $diff = round(abs(


### PR DESCRIPTION
Currently the `QueueChecker` shows a warning when a delayed message is dispatched (for example after `bin/console theme:compile`). This gets fixed by ignoring messages which should be handled in the future.

Also the `MonitoringCommand` isn't working correctly. It is using the `created_at` column instead of `available_at`. Furthermore there is an error while casting the date-string to an integer. `"2024-01-18 14:08:32"` becomes `2024` which then gets used as a timestamp which is obviously wrong. This gets fixed by using the `strtotime()` function.