### PR TITLE
fix: update min maria db to 10.11

### DIFF
--- a/src/Components/Health/Checker/HealthChecker/MysqlChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/MysqlChecker.php
@@ -41,7 +41,7 @@ class MysqlChecker implements HealthCheckerInterface, CheckerInterface
 
     private function checkMariadbVersion(HealthCollection $collection, string $version): void
     {
-        $minVersion = '10.3';
+        $minVersion = '10.11';
 
         if (version_compare($version, $minVersion, '>=')) {
             $collection->add(SettingsResult::ok(


### PR DESCRIPTION
we might have missed updating the requirements with 6.6. See: https://developer.shopware.com/release-notes/6.6/6.6.0.0.html#maria-db-10-11-minimum-requirement