### PR TITLE
Replace deprecated TaggedIterator with new AutowireIterator

### DIFF
--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -8,7 +8,7 @@ use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\PerformanceCollection;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -20,9 +20,9 @@ class HealthController extends AbstractController
      * @param CheckerInterface[] $performanceCheckers
      */
     public function __construct(
-        #[TaggedIterator('frosh_tools.health_checker')]
+        #[AutowireIterator('frosh_tools.health_checker')]
         private readonly iterable $healthCheckers,
-        #[TaggedIterator('frosh_tools.performance_checker')]
+        #[AutowireIterator('frosh_tools.performance_checker')]
         private readonly iterable $performanceCheckers,
     ) {}
 


### PR DESCRIPTION
It is not really an issue but it generates a lot of deprecation warnings, that should be cared about. Depending on the range of Shopware versions, that this is designed for we need switch around the use so we dynamically switch the name.