### PR TITLE
Fix editing nextExecutionTime of scheduled tasks

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/template.twig
@@ -35,7 +35,7 @@
                         :column="column"
                         :compact="compact"
                         :value="item[column.property]"
-                        @input="item[column.property] = $event">
+                        @update:value="item[column.property] = $event">
                 </sw-data-grid-inline-edit>
 
                 <span v-else>

--- a/src/Resources/app/administration/src/overrides/sw-data-grid-inline-edit/template.twig
+++ b/src/Resources/app/administration/src/overrides/sw-data-grid-inline-edit/template.twig
@@ -1,15 +1,19 @@
 {% block sw_data_grid_inline_edit_type_unknown %}
     <sw-datepicker
         v-else-if="column.inlineEdit === 'date'"
-        dateType="date"
-        v-model="currentValue">
-    </sw-datepicker>
+        key="date"
+        date-type="date"
+        v-model:value="currentValue"
+        name="sw-field--currentValue"
+    />
 
     <sw-datepicker
         v-else-if="column.inlineEdit === 'datetime'"
-        dateType="datetime"
-        v-model="currentValue">
-    </sw-datepicker>
+        key="datetime"
+        date-type="datetime"
+        v-model:value="currentValue"
+        name="sw-field--currentValue"
+    />
 
     {% parent() %}
 {% endblock %}


### PR DESCRIPTION
Since the Vue 3 upgrade in Shopware 6.6 it was no longer possible to edit the nextExecutionTime of scheduled tasks. This PR fixes this bug.