### PR TITLE
fix: correct reported overdue  for scheduled task

### DIFF
--- a/src/Components/Health/Checker/HealthChecker/TaskChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/TaskChecker.php
@@ -63,6 +63,6 @@ class TaskChecker implements HealthCheckerInterface, CheckerInterface
             ($maxTaskNextExecTime - $taskDateLimit->getTimestamp()) / 60,
         ));
 
-        $collection->add(SettingsResult::warning('scheduled_task', 'Scheduled tasks overdue', \sprintf('%d mins', $diff), $recommended));
+        $collection->add(SettingsResult::warning('scheduled_task', 'Scheduled tasks overdue', \sprintf('%d mins', $diff + $maxDiff), $recommended));
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/56e0cc56-62a7-4f5d-b997-c5ce51d337b4)


The message does not make sense, while 1 is lower than 10.