### PR TITLE
Fix/monitoring scheduled task always failing

### DIFF
--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -130,7 +130,7 @@ class MonitorCommand extends Command
         $criteria->addFilter(
             new RangeFilter(
                 'nextExecutionTime',
-                ['lte' => $date->format(\DATE_ATOM)]
+                ['lte' => $date->format('Y-m-d H:i:s.v')]
             )
         );
         $criteria->addFilter(new NotFilter(

--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Command;
 
+use DateTimeZone;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Mail\Service\AbstractMailService;
 use Shopware\Core\Content\Mail\Service\MailService;
@@ -123,7 +124,7 @@ class MonitorCommand extends Command
             'FroshTools.config.monitorTaskGraceTime'
         );
 
-        $date = new \DateTime();
+        $date = new \DateTime('now',new DateTimeZone('UTC'));
         $date->modify(sprintf('-%d minutes', $minutes));
 
         $criteria = new Criteria();

--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Command;
 
-use DateTimeZone;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Mail\Service\AbstractMailService;
 use Shopware\Core\Content\Mail\Service\MailService;
@@ -124,7 +123,7 @@ class MonitorCommand extends Command
             'FroshTools.config.monitorTaskGraceTime'
         );
 
-        $date = new \DateTime('now',new DateTimeZone('UTC'));
+        $date = new \DateTime();
         $date->modify(sprintf('-%d minutes', $minutes));
 
         $criteria = new Criteria();

--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -7,6 +7,7 @@ namespace Frosh\Tools\Command;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Mail\Service\AbstractMailService;
 use Shopware\Core\Content\Mail\Service\MailService;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -130,7 +131,7 @@ class MonitorCommand extends Command
         $criteria->addFilter(
             new RangeFilter(
                 'nextExecutionTime',
-                ['lte' => $date->format('Y-m-d H:i:s.v')]
+                ['lte' => $date->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
             )
         );
         $criteria->addFilter(new NotFilter(


### PR DESCRIPTION
# Why this fix?

We use the monitoring command to regularly check the scheduled task and message queue. I discovered that when running the command frosh:monitor, an email is sent regardless of the next execution time of the scheduled task.

There were 3 tasks that were always "out of schedule" regardless of the time:

```text
shopware.invalidate_cache
product_export_generate_task
shopware.elasticsearch.create.alias
```

Checking it with an SQL query revealed that the query itself is correct, only the datetime format is incorrect.

```sql
SELECT *, HEX(`id`) AS `id`
FROM `scheduled_task`
WHERE `next_execution_time` <= '2024-12-16T07:16:42+00:00' 
AND  (status NOT LIKE 'inactive');
```

The correct SQL query should look like this:

```sql
SELECT *, HEX(`id`) AS `id` 
FROM `scheduled_task` 
WHERE (`next_execution_time` <= '2024-12-16 12:56:59.264') 
AND (status NOT LIKE 'inactive')
```
## Changes
I changed the format of the `datetime` to use a supported time format from MySQL and MariaDB.
```sql 
$date->format('Y-m-d H:i:s.v')
```
## Sources
[MySQL date and time](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-type-syntax.html)<br>
[PHP datetime format](https://www.php.net/manual/en/datetime.format.php)