### PR TITLE
feat: add cache for health ping

### DIFF
--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -11,6 +11,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 #[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
 class HealthController extends AbstractController
@@ -24,6 +26,7 @@ class HealthController extends AbstractController
         private readonly iterable $healthCheckers,
         #[AutowireIterator('frosh_tools.performance_checker')]
         private readonly iterable $performanceCheckers,
+        private readonly CacheInterface $cacheObject,
     ) {}
 
     #[Route(path: '/health/status', name: 'api.frosh.tools.health.status', methods: ['GET'])]
@@ -46,5 +49,15 @@ class HealthController extends AbstractController
         }
 
         return new JsonResponse($collection);
+    }
+
+    #[Route(path: '/health-ping/status', name: 'api.frosh.tools.health-ping.status', methods: ['GET'])]
+    public function pingStatus(): JsonResponse
+    {
+        return $this->cacheObject->get('health-ping', function (ItemInterface $cacheItem) {
+            $cacheItem->expiresAfter(59);
+
+            return $this->status();
+        });
     }
 }

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -94,12 +94,17 @@ class FroshTools extends ApiService {
         });
     }
 
-    healthStatus() {
+    healthStatus(cached = false) {
         if (!this.loginService.isLoggedIn()) {
             return;
         }
 
-        const apiRoute = `${this.getApiBasePath()}/health/status`;
+        let apiRoute = `${this.getApiBasePath()}/health/status`;
+
+        if (cached) {
+            apiRoute = `${this.getApiBasePath()}/health-ping/status`;
+        }
+
         return this.httpClient.get(
             apiRoute,
             {

--- a/src/Resources/app/administration/src/overrides/sw-version/index.js
+++ b/src/Resources/app/administration/src/overrides/sw-version/index.js
@@ -63,11 +63,11 @@ Component.override('sw-version', {
 
     methods: {
         async checkHealth() {
-            this.health = await this.froshToolsService.healthStatus();
+            this.health = await this.froshToolsService.healthStatus(true);
 
             this.checkInterval = setInterval(async() => {
                 try {
-                    this.health = await this.froshToolsService.healthStatus();
+                    this.health = await this.froshToolsService.healthStatus(true);
                 } catch (e) {
                     console.error(e);
                     clearInterval(this.checkInterval);


### PR DESCRIPTION
Having multiple users in admin will result in health check performed multiple times within seconds.

I used 59 seconds for cache time because the status is taken every 60 seconds, and I want to make that there are not two pings of the same user getting the same cached response.