### PR TITLE
Add frosh-tools:health-check-json command

### DIFF
--- a/src/Command/HealthCheckJsonCommand.php
+++ b/src/Command/HealthCheckJsonCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Command;
+
+use Frosh\Tools\Components\Health\Checker\CheckerInterface;
+use Frosh\Tools\Components\Health\HealthCollection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+class HealthCheckJsonCommand extends Command
+{
+    protected static $defaultName = 'frosh-tools:health-check-json';
+
+    /**
+     * @param CheckerInterface[] $healthCheckers
+     */
+    public function __construct(
+        #[AutowireIterator('frosh_tools.health_checker')]
+        private readonly iterable $healthCheckers,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Returns a JSON with all health check checkers result merged like with /health/status route');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $collection = new HealthCollection();
+        foreach ($this->healthCheckers as $checker) {
+            $checker->collect($collection);
+        }
+
+        $output->writeln(json_encode($collection, JSON_PRETTY_PRINT));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,5 +7,6 @@
     <services>
         <defaults autowire="true" autoconfigure="true" />
         <prototype namespace="Frosh\Tools\" resource="../../" exclude="../../{DependencyInjection,Resources,FroshTools.php}" />
+        <service id="Frosh\Tools\Command\HealthCheckJsonCommand" />
     </services>
 </container>


### PR DESCRIPTION
Add a new command `frosh-tools:health-check-json` to return a JSON with all health check checkers result merged like with `/health/status` route.

* Create `HealthCheckJsonCommand` class in `src/Command/HealthCheckJsonCommand.php`
  - Implement the `Command` class from `Symfony\Component\Console\Command\Command`
  - Inject health checkers in the constructor
  - Implement the `execute` method to collect health check results and return as JSON
  - Register the command with the name `frosh-tools:health-check-json`
* Modify `src/Resources/config/services.xml`
  - Register the new `HealthCheckJsonCommand` class as a service

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FriendsOfShopware/FroshTools/pull/312?shareId=bd30d356-5303-4717-8659-6608e8069677).