### PR TITLE
feat: add logger for warnings and errors withing cached result, introduce dedicated endpoint to get just the health state

### DIFF
--- a/src/Components/Health/HealthCollection.php
+++ b/src/Components/Health/HealthCollection.php
@@ -15,4 +15,19 @@ class HealthCollection extends Collection
     {
         return SettingsResult::class;
     }
+
+    public function getState(): string
+    {
+        foreach ([SettingsResult::ERROR, SettingsResult::WARNING] as $state) {
+            $healthStatus = $this->filter(function (SettingsResult $result) use ($state) {
+                return $result->state === $state;
+            });
+
+            if ($healthStatus->count() > 0) {
+                return $state;
+            }
+        }
+
+        return SettingsResult::GREEN;
+    }
 }

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -94,16 +94,29 @@ class FroshTools extends ApiService {
         });
     }
 
-    healthStatus(cached = false) {
+    healthCheck() {
         if (!this.loginService.isLoggedIn()) {
             return;
         }
 
-        let apiRoute = `${this.getApiBasePath()}/health/status`;
+        const apiRoute = `${this.getApiBasePath()}/health/check`;
 
-        if (cached) {
-            apiRoute = `${this.getApiBasePath()}/health-ping/status`;
+        return this.httpClient.get(
+            apiRoute,
+            {
+                headers: this.getBasicHeaders()
+            }
+        ).then((response) => {
+            return ApiService.handleResponse(response);
+        });
+    }
+
+    healthStatus() {
+        if (!this.loginService.isLoggedIn()) {
+            return;
         }
+
+        const apiRoute = `${this.getApiBasePath()}/health/status`;
 
         return this.httpClient.get(
             apiRoute,

--- a/src/Resources/app/administration/src/overrides/sw-version/index.js
+++ b/src/Resources/app/administration/src/overrides/sw-version/index.js
@@ -23,51 +23,41 @@ Component.override('sw-version', {
 
     computed: {
         healthVariant() {
-            let variant = 'success';
-
-            for (let health of this.health) {
-                if (health.state === 'STATE_ERROR') {
-                    variant = 'error';
-                    continue;
-                }
-
-                if (health.state === 'STATE_WARNING' && variant === 'success') {
-                    variant = 'warning';
-                }
+            if (this.health.state === 'STATE_OK') {
+                return 'success';
             }
 
-            return variant;
+            if (this.health.state === 'STATE_WARNING') {
+                return 'warning';
+            }
+
+            return 'error';
         },
 
         healthPlaceholder() {
-            let msg = 'Shop Status: Ok';
-
             if (this.health === null) {
-                return msg;
+                return 'Shop Status: unknown';
             }
 
-            for (let health of this.health) {
-                if (health.state === 'STATE_ERROR') {
-                    msg = 'Shop Status: May outage, Check System Status';
-                    continue;
-                }
-
-                if (health.state === 'STATE_WARNING' && msg === 'Shop Status: Ok') {
-                    msg = 'Shop Status: Issues, Check System Status';
-                }
+            if (this.health.state === 'STATE_OK') {
+                return 'Shop Status: Ok';
             }
 
-            return msg;
+            if (this.health.state === 'STATE_WARNING') {
+                return 'Shop Status: Issues, Check System Status';
+            }
+
+            return 'Shop Status: May outage, Check System Status';
         }
     },
 
     methods: {
         async checkHealth() {
-            this.health = await this.froshToolsService.healthStatus(true);
+            this.health = await this.froshToolsService.healthCheck();
 
             this.checkInterval = setInterval(async() => {
                 try {
-                    this.health = await this.froshToolsService.healthStatus(true);
+                    this.health = await this.froshToolsService.healthCheck(true);
                 } catch (e) {
                     console.error(e);
                     clearInterval(this.checkInterval);

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/master/src/Core/System/SystemConfig/Schema/config.xsd">
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
 
     <card>
         <title>Monitoring</title>
@@ -30,6 +30,13 @@
             <helpText>After X minutes a scheduled task is considered stuck / faulty</helpText>
             <helpText lang="de-DE">Nach X Minuten gilt eine geplante Aufgabe als festgefahren / fehlerhaft</helpText>
             <defaultValue>10</defaultValue>
+        </input-field>
+
+        <input-field type="bool">
+            <name>healthLogger</name>
+            <label>Log health warning and error</label>
+            <label lang="de-DE">Warnungen und Fehler im HealthCheck loggen</label>
+            <defaultValue>1</defaultValue>
         </input-field>
     </card>
 


### PR DESCRIPTION
- I don't see any need, that the healthChecks need the entire data
- Logging is nice

Instead of logging, we could dispatch an event?