### PR TITLE
feat: file checker show if file patched through composer

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-files/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-files/template.twig
@@ -28,8 +28,14 @@
             </template>
 
             <template #column-expected="{ item }">
-                <span v-if="item.expected">{{ $tc('frosh-tools.tabs.files.expectedProject') }}</span>
+                <span v-if="item.patched">{{ $tc('frosh-tools.tabs.files.expectedPatched') }}</span>
+                <span v-else-if="item.expected">{{ $tc('frosh-tools.tabs.files.expectedProject') }}</span>
                 <span v-else>{{ $tc('frosh-tools.tabs.files.expectedAll') }}</span>
+                <sw-help-text
+                        style="margin-left: 8px"
+                        v-if="item.patched"
+                        :text="item.patched">
+                </sw-help-text>
             </template>
 
             <template #actions="{ item }">

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -45,6 +45,7 @@
           "restoreFile": "Datei wiederherstellen"
         },
         "expectedAll": "Datei wurde manipuliert",
+        "expectedPatched": "Datei wurde gepatcht, Fehler wird ignoriert durch Projekt Konfiguration",
         "expectedProject": "Datei wurde manipuliert, Fehler wird ignoriert durch Projekt Konfiguration"
       },
       "state-machines": {

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -45,6 +45,7 @@
           "restoreFile": "Restore file"
         },
         "expectedAll": "File has been modified",
+        "expectedPatched": "File has been patched and will be ignored by project settings",
         "expectedProject": "File has been modified, but will be ignored by project settings"
       },
       "state-machines": {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/06465b5a-d3cd-457e-90e3-926b9bb66682)

To check: handle different composer patch ways, currently tested cweagans and that seems to work fine in this case