### PR TITLE
feat: Add an tab with gmv information

### DIFF
--- a/src/Controller/GmvController.php
+++ b/src/Controller/GmvController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Controller;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+class GmvController extends AbstractController
+{
+    /**
+     * @param ServiceLocator<ReceiverInterface> $transportLocator
+     */
+    public function __construct(
+        private readonly Connection $connection,
+    ) {}
+
+    #[Route(path: '/gmv/list', name: 'api.frosh.tools.gmv.list', methods: ['GET'])]
+    public function list(): JsonResponse
+    {
+        $start = date('Y-01-01', strtotime('-1 year'));
+        $end = date('Y-m-d');
+
+        // get the liveVersionUUID
+        $context = Context::createDefaultContext();
+        $liveVersionUUID = $context->getVersionId();
+
+        $sql = "
+            SELECT ROUND(SUM(`order`.`amount_total`), 2) AS `turnover_total`,
+                   ROUND(SUM(`order`.`amount_net`), 2) AS `turnover_net`,
+                   COUNT(`order`.`id`) AS `order_count`,
+                   DATE_FORMAT(`order`.`order_date`, '%Y-%m') AS `date`,
+                   `currency`.`iso_code` AS `currency_iso_code`,
+                   `currency`.`factor` AS `currency_factor`
+            FROM `order`
+            INNER JOIN `currency` on `order`.currency_id = `currency`.`id`
+            WHERE `order`.`order_date` BETWEEN :start AND :end
+              AND `order`.`version_id` = :liveVersionId
+              AND (JSON_CONTAINS(`order`.`custom_fields`, 'true', '$.saas_test_order') IS NULL OR JSON_CONTAINS(`order`.`custom_fields`, 'true', '$.saas_test_order') = 0)
+            GROUP BY DATE_FORMAT(`order`.`order_date`, '%Y-%m'), `order`.`currency_id`
+        ";
+
+        $list = $this->connection->executeQuery($sql, [
+            'start' => $start,
+            'end' => $end,
+            'liveVersionId' => Uuid::fromHexToBytes($liveVersionUUID),
+        ])->fetchAllAssociative();
+
+        // Group data by year
+        $gmvYearly = [];
+        foreach ($list as $entry) {
+            $year = substr($entry['date'], 0, 4);
+            $currencyIsoCode = $entry['currency_iso_code'];
+            $key = $year.$currencyIsoCode;
+
+            if (!isset($gmvYearly[$key])) {
+                $gmvYearly[$key] = [
+                    'date' => $year,
+                    'turnover_total' => 0,
+                    'turnover_net' => 0,
+                    'order_count' => 0,
+                    'currency_iso_code' => $entry['currency_iso_code'],
+                    'currency_factor' => $entry['currency_factor'],
+                ];
+            }
+
+            $gmvYearly[$key]['turnover_total'] += $entry['turnover_total'];
+            $gmvYearly[$key]['turnover_net'] += $entry['turnover_net'];
+            $gmvYearly[$key]['order_count'] += $entry['order_count'];
+        }
+
+        $gmvData = [
+            'year' => $gmvYearly,
+            'month' => $list
+        ];
+
+        return new JsonResponse($gmvData);
+    }
+}

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -222,6 +222,18 @@ class FroshTools extends ApiService {
             return ApiService.handleResponse(response);
         });
     }
+
+    getGmv() {
+        const apiRoute = `${this.getApiBasePath()}/gmv/list`;
+        return this.httpClient.get(
+            apiRoute,
+            {
+                headers: this.getBasicHeaders()
+            }
+        ).then((response) => {
+            return ApiService.handleResponse(response);
+        });
+    }
 }
 
 export default FroshTools;

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-gmv/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-gmv/index.js
@@ -1,0 +1,78 @@
+import template from './template.twig';
+import './style.scss';
+
+const { Component, Mixin } = Shopware;
+
+Component.register('frosh-tools-tab-gmv', {
+    template,
+    inject: ['repositoryFactory', 'froshToolsService'],
+    mixins: [
+        Mixin.getByName('notification')
+    ],
+
+    data() {
+        return {
+            gmvEntries: [],
+            isLoading: true,
+            numberFormater: null
+        };
+    },
+
+    created() {
+        const language = Shopware.Application.getContainer('factory').locale.getLastKnownLocale();
+        this.numberFormater = new Intl.NumberFormat(
+            language,
+            { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+        );
+
+        this.createdComponent();
+    },
+
+    computed: {
+        columns() {
+            return [
+
+                {
+                    property: 'date',
+                    label: 'frosh-tools.tabs.gmv.date',
+                    rawData: true
+                },
+                {
+                    property: 'order_count',
+                    label: 'frosh-tools.tabs.gmv.orderCount',
+                    rawData: true,
+                    align: 'right'
+                },
+                {
+                    property: 'turnover_total',
+                    label: 'frosh-tools.tabs.gmv.turnoverGross',
+                    rawData: true,
+                    align: 'right'
+                },
+                {
+                    property: 'turnover_net',
+                    label: 'frosh-tools.tabs.gmv.turnoverNet',
+                    rawData: true,
+                    align: 'right'
+                }
+            ];
+        }
+    },
+
+    methods: {
+        async refresh() {
+            this.isLoading = true;
+            await this.createdComponent();
+        },
+
+        async createdComponent() {
+            this.gmvEntries = await this.froshToolsService.getGmv();
+
+            this.isLoading = false;
+        },
+
+        formatCurrency(amount, currency) {
+            return this.numberFormater.format(amount) + ' ' + currency;
+        },
+    }
+});

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-gmv/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-gmv/style.scss
@@ -1,0 +1,10 @@
+.frosh-tools-tab-gmv__manager-card {
+    .sw-card__content {
+        padding: 0;
+
+        .sw-label {
+            text-align: center;
+            min-width: 70px;
+        }
+    }
+}

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-gmv/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-gmv/template.twig
@@ -1,0 +1,58 @@
+<sw-card-view>
+    <sw-card
+            class="frosh-tools-tab-gmv__manager-card"
+            :title="$tc('frosh-tools.tabs.gmv.title')"
+            :isLoading="isLoading"
+            :large="true"
+            positionIdentifier="frosh-tools-tab-gmv"
+    >
+        <template #toolbar>
+            <sw-button variant="ghost" @click="refresh"><sw-icon :small="true" name="regular-undo"></sw-icon></sw-button>
+        </template>
+
+        <sw-card
+                class="frosh-tools-tab-gmv__yearly"
+                :title="$tc('frosh-tools.tabs.gmv.yearly')"
+                :large="true"
+                positionIdentifier="frosh-tools-tab-gmv-yearly"
+        >
+
+            <sw-data-grid
+                :showSelection="false"
+                :dataSource="gmvEntries.year"
+                :columns="columns"
+                :showActions="false"
+            >
+                <template #column-turnover_total="{ item }">
+                    {{ formatCurrency(item.turnover_total, item.currency_iso_code) }}
+                </template>
+
+                <template #column-turnover_net="{ item }">
+                    {{ formatCurrency(item.turnover_net, item.currency_iso_code) }}
+                </template>
+            </sw-data-grid>
+        </sw-card>
+
+        <sw-card
+                class="frosh-tools-tab-gmv__monthly"
+                :title="$tc('frosh-tools.tabs.gmv.monthly')"
+                :large="true"
+                positionIdentifier="frosh-tools-tab-gmv-monthly"
+        >
+            <sw-data-grid
+                :showSelection="false"
+                :dataSource="gmvEntries.month"
+                :columns="columns"
+                :showActions="false"
+            >
+                <template #column-turnover_total="{ item }">
+                    {{ formatCurrency(item.turnover_total, item.currency_iso_code) }}
+                </template>
+
+                <template #column-turnover_net="{ item }">
+                    {{ formatCurrency(item.turnover_net, item.currency_iso_code) }}
+                </template>
+            </sw-data-grid>
+        </sw-card>
+    </sw-card>
+</sw-card-view>

--- a/src/Resources/app/administration/src/module/frosh-tools/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/index.js
@@ -5,6 +5,7 @@ import './component/frosh-tools-tab-scheduled';
 import './component/frosh-tools-tab-elasticsearch';
 import './component/frosh-tools-tab-logs';
 import './component/frosh-tools-tab-state-machines';
+import './component/frosh-tools-tab-gmv';
 import './component/frosh-tools-tab-files';
 import './page/index';
 import './acl'
@@ -82,6 +83,14 @@ Shopware.Module.register('frosh-tools', {
                 statemachines: {
                     component: 'frosh-tools-tab-state-machines',
                     path: 'state-machines',
+                    meta: {
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'sw.settings.index.plugins'
+                    }
+                },
+                gmv: {
+                    component: 'frosh-tools-tab-gmv',
+                    path: 'gmv',
                     meta: {
                         privilege: 'frosh_tools:read',
                         parentPath: 'sw.settings.index.plugins'

--- a/src/Resources/app/administration/src/module/frosh-tools/page/index/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/page/index/template.twig
@@ -38,6 +38,10 @@
                     {{ $tc('frosh-tools.tabs.state-machines.title') }}
                 </sw-tabs-item>
 
+                <sw-tabs-item :route="{ name: 'frosh.tools.index.gmv' }">
+                    {{ $tc('frosh-tools.tabs.gmv.title') }}
+                </sw-tabs-item>
+
             </sw-tabs>
         </sw-container>
 

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -54,6 +54,15 @@
         "orderTitle": "Bestellstatus",
         "transactionTitle": "Bezahlstatus",
         "deliveryTitle": "Versandstatus"
+      },
+      "gmv": {
+        "title": "Brutto-Warenwert",
+        "yearly": "Jährlich",
+        "monthly": "Monatlich",
+        "date": "Datum",
+        "orderCount": "Bestellungen",
+        "turnoverGross": "Umsatz Brutto",
+        "turnoverNet": "Umsatz Netto"
       }
     },
     "clear": "Leeren",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -54,6 +54,15 @@
         "orderTitle": "Order status",
         "transactionTitle": "Transaction status",
         "deliveryTitle": "Delivery status"
+      },
+      "gmv": {
+        "title": "Gross Merchandise Volume",
+        "yearly": "Yearly",
+        "monthly": "Monthly",
+        "date": "Date",
+        "orderCount": "Orders",
+        "turnoverGross": "Turnover Gross",
+        "turnoverNet": "Turnover Net"
       }
     },
     "clear": "Clear",


### PR DESCRIPTION
For more transparent what GMV data Shopware reads from the shop, I use the query and show the Data in a Frosh Tools tab

<img width="1372" alt="Bildschirmfoto 2025-03-12 um 09 27 26" src="https://github.com/user-attachments/assets/3b8ae539-3541-49f0-8e30-791a90a4b699" />
