### PR TITLE
MySQL settings checker: Add time_zone check

### DIFF
--- a/src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php
@@ -18,6 +18,8 @@ class MysqlSettingsChecker implements PerformanceCheckerInterface, CheckerInterf
 
     public const MYSQL_SQL_MODE_PART = 'ONLY_FULL_GROUP_BY';
 
+    public const MYSQL_TIME_ZONE = '+00:00';
+
     public function __construct(private readonly Connection $connection)
     {
     }
@@ -26,6 +28,7 @@ class MysqlSettingsChecker implements PerformanceCheckerInterface, CheckerInterf
     {
         $this->checkGroupConcatMaxLen($collection);
         $this->checkSqlMode($collection);
+        $this->checkTimeZone($collection);
         $this->checkCheckDefaultEnvironmentSessionVariables($collection);
     }
 
@@ -56,6 +59,22 @@ class MysqlSettingsChecker implements PerformanceCheckerInterface, CheckerInterf
                     'MySQL value sql_mode',
                     $sqlMode,
                     'No ' . self::MYSQL_SQL_MODE_PART,
+                    self::DOCUMENTATION_URL,
+                ),
+            );
+        }
+    }
+
+    private function checkTimeZone(HealthCollection $collection): void
+    {
+        $timeZone = $this->connection->fetchOne('SELECT @@time_zone');
+        if (\is_string($timeZone) && $timeZone !== self::MYSQL_TIME_ZONE) {
+            $collection->add(
+                SettingsResult::error(
+                    'sql_time_zone',
+                    'MySQL value time_zone',
+                    $timeZone,
+                    self::MYSQL_TIME_ZONE,
                     self::DOCUMENTATION_URL,
                 ),
             );

--- a/src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php
@@ -70,7 +70,7 @@ class MysqlSettingsChecker implements PerformanceCheckerInterface, CheckerInterf
         $timeZone = $this->connection->fetchOne('SELECT @@time_zone');
         if (\is_string($timeZone) && $timeZone !== self::MYSQL_TIME_ZONE) {
             $collection->add(
-                SettingsResult::error(
+                SettingsResult::warning(
                     'sql_time_zone',
                     'MySQL value time_zone',
                     $timeZone,

--- a/src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php
@@ -18,7 +18,10 @@ class MysqlSettingsChecker implements PerformanceCheckerInterface, CheckerInterf
 
     public const MYSQL_SQL_MODE_PART = 'ONLY_FULL_GROUP_BY';
 
-    public const MYSQL_TIME_ZONE = '+00:00';
+    public const MYSQL_TIME_ZONES = [
+        '+00:00',
+        'UTC',
+    ];
 
     public function __construct(private readonly Connection $connection)
     {
@@ -68,13 +71,13 @@ class MysqlSettingsChecker implements PerformanceCheckerInterface, CheckerInterf
     private function checkTimeZone(HealthCollection $collection): void
     {
         $timeZone = $this->connection->fetchOne('SELECT @@time_zone');
-        if (\is_string($timeZone) && $timeZone !== self::MYSQL_TIME_ZONE) {
+        if (\is_string($timeZone) && \in_array($timeZone, self::MYSQL_TIME_ZONES, true)) {
             $collection->add(
                 SettingsResult::warning(
                     'sql_time_zone',
                     'MySQL value time_zone',
                     $timeZone,
-                    self::MYSQL_TIME_ZONE,
+                    implode(', ', self::MYSQL_TIME_ZONES),
                     self::DOCUMENTATION_URL,
                 ),
             );


### PR DESCRIPTION
This pull request introduces enhancements to the `MysqlSettingsChecker` class to improve the performance checks related to MySQL settings. The key changes include the addition of a new constant for MySQL time zones, the implementation of a new method to check the MySQL time zone, and the integration of this new check into the collection process.

Enhancements to MySQL settings checks:

* [`src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php`](diffhunk://#diff-815f58af033c3e62ec4e00b41280346d3d1ddadcb53089efde1c1d7ab4eadf59R21-R25): Added a new constant `MYSQL_TIME_ZONES` to store acceptable MySQL time zones.
* [`src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php`](diffhunk://#diff-815f58af033c3e62ec4e00b41280346d3d1ddadcb53089efde1c1d7ab4eadf59R34): Updated the `collect` method to include a call to the new `checkTimeZone` method.
* [`src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php`](diffhunk://#diff-815f58af033c3e62ec4e00b41280346d3d1ddadcb53089efde1c1d7ab4eadf59R71-R86): Implemented the `checkTimeZone` method to verify the MySQL time zone and add a warning to the health collection if it is not within the acceptable time zones.