### PR TITLE
PHPStan: Don't report unmatched ignored errors

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,4 @@ parameters:
     level: 8
     paths:
         - src
+    reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
Because of https://github.com/FriendsOfShopware/FroshTools/pull/322/files#file-src-components-health-checker-healthchecker-systeminfochecker-php-L41

This pull request includes a small change to the `phpstan.neon.dist` file. The change sets the `reportUnmatchedIgnoredErrors` parameter to `false`.

* [`phpstan.neon.dist`](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dR5): Added `reportUnmatchedIgnoredErrors: false` to the `parameters` section.