### PR TITLE
Fix mysql timezone check

### DIFF
--- a/src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/MysqlSettingsChecker.php
@@ -71,7 +71,7 @@ class MysqlSettingsChecker implements PerformanceCheckerInterface, CheckerInterf
     private function checkTimeZone(HealthCollection $collection): void
     {
         $timeZone = $this->connection->fetchOne('SELECT @@time_zone');
-        if (\is_string($timeZone) && \in_array($timeZone, self::MYSQL_TIME_ZONES, true)) {
+        if (\is_string($timeZone) && !\in_array($timeZone, self::MYSQL_TIME_ZONES, true)) {
             $collection->add(
                 SettingsResult::warning(
                     'sql_time_zone',


### PR DESCRIPTION
MySQL's time zone check is currently wrong. It needs to be inverted.

Currently, a warning is issued if the database time zone is `UTC` or `+00:00` However, if the time zone does not match these values, a warning should be issued.

![image](https://github.com/user-attachments/assets/48d57f3a-154e-4cab-b165-0b7c363698c3)

- See #321