### PR TITLE
fix: check for message in LogController

### DIFF
--- a/src/Controller/LogController.php
+++ b/src/Controller/LogController.php
@@ -52,7 +52,7 @@ class LogController extends AbstractController
 
         /** @var string $item */
         foreach ($reader as $item) {
-            if (preg_match(self::LINE_MATCH, $item, $matches) === false || !array_key_exists('message', $matches)) {
+            if (preg_match(self::LINE_MATCH, $item, $matches) !== 1) {
                 $result[] = [
                     'message' => $item,
                     'channel' => 'unknown',

--- a/src/Controller/LogController.php
+++ b/src/Controller/LogController.php
@@ -52,7 +52,7 @@ class LogController extends AbstractController
 
         /** @var string $item */
         foreach ($reader as $item) {
-            if (preg_match(self::LINE_MATCH, $item, $matches) === false) {
+            if (preg_match(self::LINE_MATCH, $item, $matches) === false || !array_key_exists('message', $matches)) {
                 $result[] = [
                     'message' => $item,
                     'channel' => 'unknown',


### PR DESCRIPTION
if the log file is not correct formatted the log is flooded with ` php.ERROR: Warning: Undefined array key "message"`...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log line parsing to ensure only successfully matched lines are processed, resulting in more accurate log detail extraction and better handling of non-matching lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->