### PR TITLE
feat: add functionality for plugin checksums

### DIFF
--- a/src/Command/PluginChecksumCheckCommand.php
+++ b/src/Command/PluginChecksumCheckCommand.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+namespace Frosh\Tools\Command;
+
+use Frosh\Tools\Components\PluginChecksum\PluginFileHashService;
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Plugin\PluginCollection;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'frosh:plugin:checksum:check',
+    description: 'Check the integrity of plugin files',
+)]
+class PluginChecksumCheckCommand extends Command
+{
+    /**
+     * @param EntityRepository<PluginCollection> $pluginRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $pluginRepository,
+        private readonly PluginFileHashService $pluginFileHashService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('plugin', InputArgument::OPTIONAL, 'Plugin name');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+
+        $plugins = $this->getPlugins((string) $input->getArgument('plugin'), $io);
+        if ($plugins->count() === 0) {
+            $io->error('No plugins found');
+
+            return self::FAILURE;
+        }
+
+        $success = true;
+        foreach ($plugins as $plugin) {
+            $io->info('Checking plugin: ' . $plugin->getName());
+
+            $pluginChecksumCheckResult = $this->pluginFileHashService->checkPluginForChanges($plugin);
+            if ($pluginChecksumCheckResult->isFileMissing()) {
+                $io->info(\sprintf('Plugin "%s" checksum file for not found', $plugin->getName()));
+
+                continue;
+            }
+
+            if ($pluginChecksumCheckResult->isWrongVersion()) {
+                $io->error(\sprintf('Checksum file for plugin "%s" was generated for different version', $plugin->getName()));
+
+                continue;
+            }
+
+            if ($pluginChecksumCheckResult->getNewFiles() === []
+                && $pluginChecksumCheckResult->getChangedFiles() === []
+                && $pluginChecksumCheckResult->getMissingFiles() === []
+            ) {
+                $io->success(\sprintf('Plugin "%s" has no detected file-changes.', $plugin->getName()));
+
+                continue;
+            }
+
+            $success = false;
+
+            $io->error(\sprintf('Plugin "%s" has changed code.', $plugin->getName()));
+            $this->outputFileChanges($io, 'New files detected:', $pluginChecksumCheckResult->getNewFiles());
+            $this->outputFileChanges($io, 'Changed files detected:', $pluginChecksumCheckResult->getChangedFiles());
+            $this->outputFileChanges($io, 'Missing files detected:', $pluginChecksumCheckResult->getMissingFiles());
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function getPlugins(string $pluginName, ShopwareStyle $io): PluginCollection
+    {
+        $context = Context::createCLIContext();
+
+        if (!$pluginName) {
+            $io->info('Checking all plugins');
+
+            /** @var PluginCollection $plugins */
+            $plugins = $this->pluginRepository->search(new Criteria(), $context)->getEntities();
+
+            return $plugins;
+        }
+
+        $plugins = new PluginCollection();
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $pluginName));
+        $plugin = $this->pluginRepository->search($criteria, $context)->first();
+        if ($plugin instanceof PluginEntity) {
+            $plugins->add($plugin);
+        }
+
+        return $plugins;
+    }
+
+    /**
+     * @param string[] $files
+     */
+    private function outputFileChanges(ShopwareStyle $io, string $text, array $files): void
+    {
+        if ($files) {
+            $io->warning($text);
+            $io->listing($files);
+        }
+    }
+}

--- a/src/Command/PluginChecksumCreateCommand.php
+++ b/src/Command/PluginChecksumCreateCommand.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Frosh\Tools\Command;
+
+use Frosh\Tools\Components\PluginChecksum\PluginFileHashService;
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Plugin\PluginCollection;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'frosh:plugin:checksum:create',
+    description: 'Creates a list of files and their checksums for a plugin',
+)]
+class PluginChecksumCreateCommand extends Command
+{
+    /**
+     * @param EntityRepository<PluginCollection> $pluginRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $pluginRepository,
+        private readonly PluginFileHashService $pluginFileHashService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('plugin', InputArgument::REQUIRED, 'Plugin name');
+        $this->addOption('file-extensions', null, InputOption::VALUE_OPTIONAL, 'Comma-separated list of file extensions to include in the checksum (example: "*.php,*.twig")', '*.php,*.twig');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+        $context = Context::createCLIContext();
+
+        $pluginName = (string) $input->getArgument('plugin');
+        $plugin = $this->getPlugin($pluginName, $context);
+
+        if (!$plugin instanceof PluginEntity) {
+            $io->error(\sprintf('Plugin "%s" not found', $pluginName));
+
+            return self::FAILURE;
+        }
+
+        $fileExtensions = array_unique(array_filter(\explode(',', (string) $input->getOption('file-extensions'))));
+        if ($fileExtensions === []) {
+            $io->error('No valid file extensions provided');
+
+            return self::FAILURE;
+        }
+
+        $checksumFilePath = $this->pluginFileHashService->getChecksumFilePathForPlugin($plugin);
+        if (!$checksumFilePath) {
+            $io->error(\sprintf('Plugin "%s" checksum file path could not be identified', $plugin->getName()));
+
+            return self::FAILURE;
+        }
+
+        $checksumStruct = $this->pluginFileHashService->getChecksumData($plugin, $fileExtensions);
+
+        $io->info(\sprintf('Writing %s checksums for plugin "%s" to file %s', \count($checksumStruct->getHashes()), $plugin->getName(), $checksumFilePath));
+
+        file_put_contents($checksumFilePath, \json_encode($checksumStruct->jsonSerialize(), \JSON_THROW_ON_ERROR));
+
+        return self::SUCCESS;
+    }
+
+    private function getPlugin(string $pluginName, Context $context): ?Entity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $pluginName));
+
+        return $this->pluginRepository->search($criteria, $context)->first();
+    }
+}

--- a/src/Components/PluginChecksum/PluginFileHashService.php
+++ b/src/Components/PluginChecksum/PluginFileHashService.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+namespace Frosh\Tools\Components\PluginChecksum;
+
+use Frosh\Tools\Components\PluginChecksum\Struct\PluginChecksumCheckResult;
+use Frosh\Tools\Components\PluginChecksum\Struct\PluginChecksumStruct;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Framework\Util\Hasher;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Finder\Finder;
+
+class PluginFileHashService
+{
+    public const CHECKSUM_FILE = 'checksums.json';
+
+    public function __construct(
+        #[Autowire('%kernel.project_dir%')]
+        private readonly string $rootDir,
+    ) {
+    }
+
+    public function getChecksumFilePathForPlugin(PluginEntity $plugin): string
+    {
+        return "$this->rootDir/{$plugin->getPath()}" . self::CHECKSUM_FILE;
+    }
+
+    /**
+     * @param string[] $fileExtensions
+     */
+    public function getChecksumData(PluginEntity $plugin, array $fileExtensions): PluginChecksumStruct
+    {
+        return PluginChecksumStruct::fromArray([
+            'algorithm' => Hasher::ALGO,
+            'fileExtensions' => $fileExtensions,
+            'hashes' => $this->getHashes($plugin, $fileExtensions),
+            'pluginVersion' => $plugin->getVersion(),
+        ]);
+    }
+
+    public function checkPluginForChanges(PluginEntity $plugin): PluginChecksumCheckResult
+    {
+        $checksumFilePath = $this->getChecksumFilePathForPlugin($plugin);
+        if (!is_file($checksumFilePath)) {
+            return new PluginChecksumCheckResult(fileMissing: true);
+        }
+
+        $checksumFileContent = (string) file_get_contents($checksumFilePath);
+        $checksumFileData = PluginChecksumStruct::fromArray(json_decode($checksumFileContent, true, 512, \JSON_THROW_ON_ERROR));
+
+        $extensions = $checksumFileData->getFileExtensions();
+        $checksumPluginVersion = $checksumFileData->getPluginVersion();
+
+        if ($plugin->getVersion() !== $checksumPluginVersion) {
+            return new PluginChecksumCheckResult(wrongVersion: true);
+        }
+
+        $currentHashes = $this->getHashes($plugin, $extensions, $checksumFileData->getAlgorithm());
+        $previouslyHashedFiles = $checksumFileData->getHashes();
+
+        $newFiles = array_diff_key($currentHashes, $previouslyHashedFiles);
+        $missingFiles = array_diff_key($previouslyHashedFiles, $currentHashes);
+        $manipulatedFiles = array_diff(array_diff_key($previouslyHashedFiles, $missingFiles, $newFiles), $currentHashes);
+
+        return new PluginChecksumCheckResult(
+            newFiles: array_keys($newFiles),
+            changedFiles: array_keys($manipulatedFiles),
+            missingFiles: array_keys($missingFiles),
+        );
+    }
+
+    /**
+     * @param string[] $extensions
+     *
+     * @return array<string, string>
+     */
+    private function getHashes(PluginEntity $plugin, array $extensions, ?string $algorithm = null): array
+    {
+        $algorithm = $algorithm ?? Hasher::ALGO;
+        $pluginPath = $plugin->getPath();
+        if ($pluginPath === null) {
+            return [];
+        }
+
+        $directories = $this->getDirectories($plugin);
+
+        $finder = new Finder();
+        $finder->in($directories)->files()->name($extensions);
+
+        $hashes = [];
+        foreach ($finder as $file) {
+            $absoluteFilePath = $file->getRealPath();
+            if (!\is_string($absoluteFilePath) || !$absoluteFilePath) {
+                continue;
+            }
+
+            $relativePath = (string) str_replace($this->rootDir . '/' . $pluginPath, '', $absoluteFilePath);
+
+            $hashes[$relativePath] = Hasher::hashFile($absoluteFilePath, $algorithm);
+        }
+
+        return $hashes;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getDirectories(PluginEntity $plugin): array
+    {
+        $directories = [];
+
+        $autoload = $plugin->getAutoload();
+        $psr4 = $autoload['psr-4'] ?? [];
+        foreach ($psr4 as $path) {
+            if (\is_string($path) && $path !== '') {
+                $directories[] = "$this->rootDir/{$plugin->getPath()}$path";
+            }
+        }
+
+        return array_unique($directories);
+    }
+}

--- a/src/Components/PluginChecksum/Struct/PluginChecksumCheckResult.php
+++ b/src/Components/PluginChecksum/Struct/PluginChecksumCheckResult.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Frosh\Tools\Components\PluginChecksum\Struct;
+
+use Shopware\Core\Framework\Struct\Struct;
+
+class PluginChecksumCheckResult extends Struct
+{
+    /**
+     * @param string[] $newFiles
+     * @param string[] $changedFiles
+     * @param string[] $missingFiles
+     */
+    public function __construct(
+        protected bool $fileMissing = false,
+        protected bool $wrongVersion = false,
+        protected array $newFiles = [],
+        protected array $changedFiles = [],
+        protected array $missingFiles = [],
+    ) {
+    }
+
+    public function isFileMissing(): bool
+    {
+        return $this->fileMissing;
+    }
+
+    public function isWrongVersion(): bool
+    {
+        return $this->wrongVersion;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNewFiles(): array
+    {
+        return $this->newFiles;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getChangedFiles(): array
+    {
+        return $this->changedFiles;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMissingFiles(): array
+    {
+        return $this->missingFiles;
+    }
+}

--- a/src/Components/PluginChecksum/Struct/PluginChecksumStruct.php
+++ b/src/Components/PluginChecksum/Struct/PluginChecksumStruct.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Frosh\Tools\Components\PluginChecksum\Struct;
+
+use Shopware\Core\Framework\Struct\Struct;
+
+class PluginChecksumStruct extends Struct
+{
+    protected string $algorithm;
+
+    /**
+     * @var array<string>
+     */
+    protected array $fileExtensions;
+
+    /**
+     * @var array<string>
+     */
+    protected array $hashes;
+
+    protected string $pluginVersion;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return (new self())->assign($data);
+    }
+
+    public function getAlgorithm(): string
+    {
+        return $this->algorithm;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getFileExtensions(): array
+    {
+        return $this->fileExtensions;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getHashes(): array
+    {
+        return $this->hashes;
+    }
+
+    public function getPluginVersion(): string
+    {
+        return $this->pluginVersion;
+    }
+}

--- a/src/Controller/PluginFilesController.php
+++ b/src/Controller/PluginFilesController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Controller;
+
+use Frosh\Tools\Components\PluginChecksum\PluginFileHashService;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Plugin\PluginCollection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AutoconfigureTag('monolog.logger', ['channel' => 'frosh-tools'])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+class PluginFilesController extends AbstractController
+{
+    /**
+     * @param EntityRepository<PluginCollection> $pluginRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $pluginRepository,
+        private readonly PluginFileHashService $pluginFileHashService,
+    ) {
+    }
+
+    #[Route(path: '/plugin-files', name: 'api.frosh.tools.plugin-files', methods: ['GET'])]
+    public function listPluginFiles(Context $context): JsonResponse
+    {
+        $pluginResults = [];
+
+        /** @var PluginCollection $plugins */
+        $plugins = $this->pluginRepository->search(new Criteria(), $context)->getEntities();
+        foreach ($plugins as $plugin) {
+            $pluginChecksumCheckResult = $this->pluginFileHashService->checkPluginForChanges($plugin);
+            if ($pluginChecksumCheckResult->getNewFiles() !== [] || $pluginChecksumCheckResult->getChangedFiles() !== [] || $pluginChecksumCheckResult->getMissingFiles() !== []) {
+                $pluginResults[$plugin->getName()] = $pluginChecksumCheckResult;
+            }
+        }
+
+        return new JsonResponse(['success' => \count($pluginResults) === 0, 'pluginResults' => $pluginResults]);
+    }
+}

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -180,6 +180,17 @@ class FroshTools extends ApiService {
       })
   }
 
+  getPluginFiles() {
+    const apiRoute = `${this.getApiBasePath()}/plugin-files`
+    return this.httpClient
+      .get(apiRoute, {
+        headers: this.getBasicHeaders(),
+      })
+      .then((response) => {
+        return response
+      })
+  }
+
   getFileContents(file) {
     const apiRoute = `${this.getApiBasePath()}/file-contents`
     return this.httpClient

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-files/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-files/index.js
@@ -11,6 +11,7 @@ Component.register('frosh-tools-tab-files', {
   data() {
     return {
       items: {},
+      pluginItems: {},
       isLoading: true,
       diffData: {
         html: '',
@@ -57,6 +58,7 @@ Component.register('frosh-tools-tab-files', {
 
     async createdComponent() {
       this.items = (await this.froshToolsService.getShopwareFiles()).data
+      this.pluginItems = (await this.froshToolsService.getPluginFiles()).data
       this.isLoading = false
     },
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-files/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-files/template.twig
@@ -88,4 +88,62 @@
             </sw-button>
         </template>
     </sw-modal>
+    <sw-card
+        class="frosh-tools-tab-files__plugin-files-card"
+        :class="isLoadingClass"
+        :title="$t('frosh-tools.tabs.pluginFiles.title')"
+        :isLoading="isLoading"
+        :large="true"
+        positionIdentifier="frosh-tools-tab-files__plugin-files-card"
+    >
+        <sw-alert
+            variant="success"
+            v-if="pluginItems.success"
+        >
+            {{ $t('frosh-tools.tabs.pluginFiles.allFilesOk') }}
+        </sw-alert>
+        <sw-alert
+            variant="warning"
+            v-else
+        >
+            {{ $t('frosh-tools.tabs.pluginFiles.notOk') }}
+        </sw-alert>
+        <template #toolbar>
+            <!-- @todo: Make the refresh button fancy -->
+            <sw-button
+                variant="ghost"
+                @click="refresh"
+            >
+                <sw-icon
+                    :small="true"
+                    name="regular-undo"
+                ></sw-icon>
+            </sw-button>
+        </template>
+        <div
+            v-for="(plugin, pluginName) in pluginItems.pluginResults"
+        >
+            <h4>{{ pluginName }}</h4>
+            <sw-description-list>
+                <dt v-if="plugin.newFiles.length > 0">
+                    {{ $t('frosh-tools.tabs.pluginFiles.newFiles') }}
+                </dt>
+                <dd v-for="file in plugin.newFiles">
+                    {{ file }}
+                </dd>
+                <dt v-if="plugin.changedFiles.length > 0">
+                    {{ $t('frosh-tools.tabs.pluginFiles.changedFiles') }}
+                </dt>
+                <dd v-for="file in plugin.changedFiles">
+                    {{ file }}
+                </dd>
+                <dt v-if="plugin.missingFiles.length > 0">
+                    {{ $t('frosh-tools.tabs.pluginFiles.missingFiles') }}
+                </dt>
+                <dd v-for="file in plugin.missingFiles">
+                    {{ file }}
+                </dd>
+            </sw-description-list>
+        </div>
+    </sw-card>
 </sw-card-view>

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -62,6 +62,14 @@
         "expectedAll": "Datei wurde manipuliert",
         "expectedProject": "Datei wurde manipuliert, Fehler wird ignoriert durch Projekt Konfiguration"
       },
+      "pluginFiles": {
+        "title": "Plugin Dateien Checker",
+        "allFilesOk": "Keine Plugins wurden manipuliert",
+        "notOk": "Es gibt Plugins, die manipuliert wurden",
+        "newFiles": "Neue Dateien",
+        "changedFiles": "Geänderte Dateien",
+        "missingFiles": "Fehlende Dateien"
+      },
       "state-machines": {
         "title": "State Machine Viewer",
         "label": "State Machine",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -62,6 +62,14 @@
         "expectedAll": "File has been modified",
         "expectedProject": "File has been modified, but will be ignored by project settings"
       },
+      "pluginFiles": {
+        "title": "Plugin File Checker",
+        "allFilesOk": "No plugins modified",
+        "notOk": "There are modified plugins",
+        "newFiles": "New files",
+        "changedFiles": "Changed files",
+        "missingFiles": "Missing files"
+      },
       "state-machines": {
         "title": "State Machine Viewer",
         "label": "State Machine",


### PR DESCRIPTION
### Why is this change necessary?

Plugin developers have no way to see if their plugin code has been modified other than checking each file. This functionality was included in Shopware 5.

### What does this change do, exactly?

It adds 2 commands for the CLI 

- `frosh:plugin:checksum:check` Check the integrity of plugin files
- `frosh:plugin:checksum:create` Creates a list of files and their checksums for a plugin

It adds a list in the administration of FroshTools (`/admin#/frosh/tools/index/files`)

![image](https://github.com/user-attachments/assets/1445ff74-cf3b-4930-94d9-df7397d28378)


### Where is this from? 

Ported from https://github.com/shopware/shopware/pull/5362 because it was recommended to move it here. 

