### PR TITLE
fix: disable product indexing checker hint for versions <6.6.10.5

### DIFF
--- a/src/Components/Health/Checker/PerformanceChecker/ProductStreamIndexingChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/ProductStreamIndexingChecker.php
@@ -14,11 +14,18 @@ class ProductStreamIndexingChecker implements PerformanceCheckerInterface, Check
     public function __construct(
         #[Autowire(param: 'shopware.product_stream.indexing')]
         private readonly bool $productStreamIndexingEnabled,
+        #[Autowire(param: 'kernel.shopware_version')]
+        private readonly string $shopwareVersion,
     ) {
     }
 
     public function collect(HealthCollection $collection): void
     {
+        // https://github.com/FriendsOfShopware/FroshTools/issues/342#issuecomment-2865874897
+        if (\version_compare('6.6.10.5', $this->shopwareVersion, '>')) {
+            return;
+        }
+
         if ($this->productStreamIndexingEnabled) {
             $collection->add(
                 SettingsResult::info(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled the product stream indexing health check for Shopware versions older than 6.6.10.5 to prevent incorrect or unnecessary alerts on unsupported versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->