### PR TITLE
Skip `fine-grained-caching` check for >= 6.7

### DIFF
--- a/src/Components/Health/Checker/PerformanceChecker/FineGrainedCachingChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/FineGrainedCachingChecker.php
@@ -29,6 +29,11 @@ class FineGrainedCachingChecker implements PerformanceCheckerInterface, CheckerI
             return;
         }
 
+        // Fine-grained caching was removed in 6.7.0.0
+        if (\version_compare($this->shopwareVersion, '6.7.0.0', '>=')) {
+            return;
+        }
+
         if ($this->cacheTaggingEachConfig || $this->cacheTaggingEachSnippet || $this->cacheTaggingEachThemeConfig) {
             $collection->add(
                 // only info, because it only affects redis, varnish etc.


### PR DESCRIPTION
- Shopware Release 6.7.0.0 removed the `fine-grained-caching` feature, we should skip the check if the Shopware Version is >= 6.7