### PR TITLE
Skip fix cache ID performance check from 6.7.0.0

### DIFF
--- a/src/Components/Health/Checker/PerformanceChecker/FixCacheIdSetChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/FixCacheIdSetChecker.php
@@ -24,6 +24,10 @@ class FixCacheIdSetChecker implements PerformanceCheckerInterface, CheckerInterf
             return;
         }
 
+        if (\version_compare($this->shopwareVersion, '6.7.0.0', '>=')) {
+            return;
+        }
+
         $cacheId = (string) EnvironmentHelper::getVariable('SHOPWARE_CACHE_ID', '');
 
         if ($cacheId === '') {


### PR DESCRIPTION
For Shopware 6.7 the Cache ID [performance tweak](https://developer.shopware.com/docs/guides/hosting/performance/performance-tweaks.html) is not documented anymore so I think it should not be recommended.