### PR TITLE
Update admin index prefix matching to use '-' instead of '_'

### DIFF
--- a/src/Components/Elasticsearch/ElasticsearchManager.php
+++ b/src/Components/Elasticsearch/ElasticsearchManager.php
@@ -159,6 +159,6 @@ class ElasticsearchManager
     private function matchesPrefix(string $indexName): bool
     {
         return str_starts_with($indexName, $this->indexPrefix . '_')
-            || str_starts_with($indexName, $this->adminIndexPrefix . '_');
+            || str_starts_with($indexName, $this->adminIndexPrefix . '-');
     }
 }


### PR DESCRIPTION
See https://github.com/shopware/shopware/blob/trunk/src/Elasticsearch/Admin/AdminElasticsearchHelper.php#L52 for index name generation