### PR TITLE
fix: support Redis & AMQP transports in queue monitoring (#393)

### DIFF
--- a/src/Components/Elasticsearch/ElasticsearchManager.php
+++ b/src/Components/Elasticsearch/ElasticsearchManager.php
@@ -153,7 +153,11 @@ class ElasticsearchManager
             // In case message_queue pool is disabled
         }
 
-        $this->connection->executeStatement('DELETE FROM messenger_messages WHERE body LIKE "%ElasticsearchIndexingMessage%"');
+        try {
+            $this->connection->executeStatement('DELETE FROM messenger_messages WHERE body LIKE "%ElasticsearchIndexingMessage%"');
+        } catch (\Doctrine\DBAL\Exception) {
+            // messenger_messages table is not present when the configured transport is not Doctrine
+        }
     }
 
     private function matchesPrefix(string $indexName): bool

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Components\Health\Checker\HealthChecker;
 
-use Doctrine\DBAL\Connection;
 use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
@@ -22,7 +21,6 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
      * @param ServiceLocator<ReceiverInterface> $transportLocator
      */
     public function __construct(
-        private readonly Connection $connection,
         private readonly SystemConfigService $configService,
         #[Autowire(service: 'messenger.receiver_locator')]
         private readonly ServiceLocator $transportLocator,
@@ -32,44 +30,47 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
     public function collect(HealthCollection $collection): void
     {
         $maxDiff = $this->configService->getInt('FroshTools.config.monitorQueueGraceTime') ?: 15;
-        $oldMessageLimit = (new \DateTimeImmutable())->modify(\sprintf('-%d minutes', $maxDiff));
-
         $snippet = 'Open Queues';
         $recommended = \sprintf('max %d mins', $maxDiff);
 
-        // 1) Try the Doctrine path first — it gives the richest info (oldest message age).
-        //    If the messenger_messages table is missing or the query fails, fall through
-        //    to the transport-based path.
-        try {
-            /** @var string|false $oldestMessageAt */
-            $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages WHERE available_at < UTC_TIMESTAMP() ORDER BY available_at ASC LIMIT 1');
-        } catch (\Doctrine\DBAL\Exception) {
-            $oldestMessageAt = false;
-        }
+        // Always prefer transport-based counting. This is the source of truth for the
+        // currently configured transports and bypasses stale rows that may still be
+        // sitting in the messenger_messages table from a previous Doctrine configuration.
+        //
+        // Symfony's DoctrineTransport, RedisTransport, and others all implement
+        // MessageCountAwareInterface, so "active" messages always show up here regardless
+        // of the underlying backend.
+        [$totalCount, $hasCountableTransport] = $this->countPendingFromTransports();
 
-        if (\is_string($oldestMessageAt)) {
-            $diff = round(abs(
-                ((new \DateTime($oldestMessageAt . ' UTC'))->getTimestamp() - $oldMessageLimit->getTimestamp()) / 60,
-            ));
-
-            if ($diff > $maxDiff) {
-                $result = SettingsResult::warning('queue', $snippet, $diff . ' mins', $recommended);
+        if ($hasCountableTransport) {
+            if ($totalCount === 0) {
+                $result = SettingsResult::ok('queue', $snippet, '0 pending', $recommended);
             } else {
-                $result = SettingsResult::ok('queue', $snippet, $diff . ' mins', $recommended);
+                // We know the count but not the age. A persistently non-zero count is
+                // the actual "stuck queue" signal; the user can drill down via the queue
+                // list tab if they need per-transport details.
+                $result = SettingsResult::ok('queue', $snippet, $totalCount . ' pending', $recommended);
             }
+
             $result->url = self::URL;
             $collection->add($result);
 
             return;
         }
 
-        // 2) Transport-based path: works for any transport that implements
-        //    MessageCountAwareInterface (Doctrine with empty table, Redis, …). AMQP does
-        //    not implement it in Symfony core and will fall through to the INFO default.
-        $collection->add($this->collectFromTransports($snippet, $recommended));
+        // No transport in the locator supports counting (e.g. pure AMQP setup). We
+        // deliberately do NOT fall back to reading messenger_messages, because any rows
+        // we find there are almost certainly leftover from a previous configuration and
+        // would produce a misleading warning.
+        $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
+        $result->url = self::URL;
+        $collection->add($result);
     }
 
-    private function collectFromTransports(string $snippet, string $recommended): SettingsResult
+    /**
+     * @return array{int, bool} [totalCount, hasCountableTransport]
+     */
+    private function countPendingFromTransports(): array
     {
         $totalCount = 0;
         $hasCountableTransport = false;
@@ -77,7 +78,7 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         try {
             $providedServices = array_keys($this->transportLocator->getProvidedServices());
         } catch (\Throwable) {
-            $providedServices = [];
+            return [0, false];
         }
 
         foreach ($providedServices as $name) {
@@ -106,19 +107,6 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
             }
         }
 
-        if (!$hasCountableTransport) {
-            $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
-        } elseif ($totalCount === 0) {
-            $result = SettingsResult::ok('queue', $snippet, '0 pending', $recommended);
-        } else {
-            // We know the count but not the age of individual messages, so a high count
-            // alone is not a reliable "stuck" signal. Report as OK and let the user drill
-            // down via the queue list tab if they want more detail.
-            $result = SettingsResult::ok('queue', $snippet, $totalCount . ' pending', $recommended);
-        }
-
-        $result->url = self::URL;
-
-        return $result;
+        return [$totalCount, $hasCountableTransport];
     }
 }

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -7,6 +7,7 @@ namespace Frosh\Tools\Components\Health\Checker\HealthChecker;
 use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
+use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -24,6 +25,8 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         private readonly SystemConfigService $configService,
         #[Autowire(service: 'messenger.receiver_locator')]
         private readonly ServiceLocator $transportLocator,
+        #[Autowire(service: 'shopware.increment.gateway.registry')]
+        private readonly IncrementGatewayRegistry $incrementGatewayRegistry,
     ) {
     }
 
@@ -33,36 +36,42 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         $snippet = 'Open Queues';
         $recommended = \sprintf('max %d mins', $maxDiff);
 
-        // Always prefer transport-based counting. This is the source of truth for the
-        // currently configured transports and bypasses stale rows that may still be
-        // sitting in the messenger_messages table from a previous Doctrine configuration.
+        // Two sources for "how much is pending":
         //
-        // Symfony's DoctrineTransport, RedisTransport, and others all implement
-        // MessageCountAwareInterface, so "active" messages always show up here regardless
-        // of the underlying backend.
-        [$totalCount, $hasCountableTransport] = $this->countPendingFromTransports();
+        //  1) messenger.receiver_locator → MessageCountAwareInterface. Source of truth
+        //     for the actual state of the configured transport backend(s) (Doctrine,
+        //     Redis, …).
+        //  2) shopware.increment.gateway.registry → "message_queue" pool, key
+        //     "message_queue_stats". Shopware increments this on dispatch and
+        //     decrements on handle. A stuck counter here (handler crashed before
+        //     decrement) is exactly the state the queue list tab surfaces but the
+        //     transport backend no longer reflects.
+        //
+        // Using the maximum of both makes the Open Queues row agree with the queue
+        // list tab: a stuck counter shows up as pending and can be cleared via the
+        // "Reset Queue" button in the admin.
+        [$transportCount, $hasCountableTransport] = $this->countPendingFromTransports();
+        $incrementerCount = $this->countPendingFromIncrementer();
+        $displayCount = max($transportCount, $incrementerCount);
 
-        if ($hasCountableTransport) {
-            if ($totalCount === 0) {
+        if ($hasCountableTransport || $incrementerCount > 0) {
+            if ($displayCount === 0) {
                 $result = SettingsResult::ok('queue', $snippet, '0 pending', $recommended);
             } else {
-                // We know the count but not the age. A persistently non-zero count is
-                // the actual "stuck queue" signal; the user can drill down via the queue
-                // list tab if they need per-transport details.
-                $result = SettingsResult::ok('queue', $snippet, $totalCount . ' pending', $recommended);
+                // We know the count but not the age of individual messages. A
+                // persistently non-zero count is the real stuck-queue signal; drill
+                // down via the queue list tab for per-message details.
+                $result = SettingsResult::ok('queue', $snippet, $displayCount . ' pending', $recommended);
             }
-
-            $result->url = self::URL;
-            $collection->add($result);
-
-            return;
+        } else {
+            // Neither the transport locator nor the incrementer gave us anything
+            // usable (e.g. pure AMQP setup with the increment pool disabled). We do
+            // NOT fall back to reading messenger_messages, because any rows there are
+            // almost certainly leftovers from a previous configuration and would
+            // produce a misleading warning.
+            $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
         }
 
-        // No transport in the locator supports counting (e.g. pure AMQP setup). We
-        // deliberately do NOT fall back to reading messenger_messages, because any rows
-        // we find there are almost certainly leftover from a previous configuration and
-        // would produce a misleading warning.
-        $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
         $result->url = self::URL;
         $collection->add($result);
     }
@@ -108,5 +117,25 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         }
 
         return [$totalCount, $hasCountableTransport];
+    }
+
+    private function countPendingFromIncrementer(): int
+    {
+        try {
+            $gateway = $this->incrementGatewayRegistry->get('message_queue');
+            $list = $gateway->list('message_queue_stats', -1);
+        } catch (\Throwable) {
+            // Increment pool not configured, backend unreachable, etc.
+            return 0;
+        }
+
+        $total = 0;
+        foreach ($list as $entry) {
+            if (\is_array($entry) && isset($entry['count'])) {
+                $total += (int) $entry['count'];
+            }
+        }
+
+        return $total;
     }
 }

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -38,7 +38,6 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
     {
         $maxDiff = $this->configService->getInt('FroshTools.config.monitorQueueGraceTime') ?: 15;
         $snippet = 'Open Queues';
-        $recommended = \sprintf('max %d mins', $maxDiff);
 
         [$transportCount, $hasCountableTransport, $hasDoctrineTransport] = $this->inspectTransports();
         $incrementerCount = $this->countPendingFromIncrementer();
@@ -48,7 +47,7 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         //    display. The table is the source of truth while Doctrine is live; processed
         //    messages get deleted, so any row we find is actually pending.
         if ($hasDoctrineTransport) {
-            $result = $this->doctrineAgeBasedResult($snippet, $recommended, $maxDiff);
+            $result = $this->doctrineAgeBasedResult($snippet, $maxDiff);
             $result->url = self::URL;
             $collection->add($result);
 
@@ -58,7 +57,7 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         // 2) No Doctrine transport is active, but some count-capable transport is (Redis,
         //    …) — or the Shopware increment gateway has data. Use a count-based display.
         if ($hasCountableTransport || $incrementerCount > 0) {
-            $result = $this->countBasedResult($snippet, $recommended, $transportCount, $incrementerCount);
+            $result = $this->countBasedResult($snippet, $transportCount, $incrementerCount);
             $result->url = self::URL;
             $collection->add($result);
 
@@ -69,7 +68,7 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         //    deliberately do NOT fall back to messenger_messages here, because without an
         //    active Doctrine transport any rows we find there are almost certainly stale
         //    leftovers from a previous configuration.
-        $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
+        $result = SettingsResult::info('queue', $snippet, 'not monitorable', 'n/a');
         $result->url = self::URL;
         $collection->add($result);
     }
@@ -143,13 +142,15 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         return $total;
     }
 
-    private function doctrineAgeBasedResult(string $snippet, string $recommended, int $maxDiff): SettingsResult
+    private function doctrineAgeBasedResult(string $snippet, int $maxDiff): SettingsResult
     {
+        $recommended = \sprintf('max %d mins', $maxDiff);
+
         try {
             /** @var string|false $oldestMessageAt */
             $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages WHERE available_at < UTC_TIMESTAMP() ORDER BY available_at ASC LIMIT 1');
         } catch (\Doctrine\DBAL\Exception) {
-            return SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
+            return SettingsResult::info('queue', $snippet, 'not monitorable', 'n/a');
         }
 
         if (!\is_string($oldestMessageAt)) {
@@ -168,8 +169,10 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         return SettingsResult::ok('queue', $snippet, $diff . ' mins', $recommended);
     }
 
-    private function countBasedResult(string $snippet, string $recommended, int $transportCount, int $incrementerCount): SettingsResult
+    private function countBasedResult(string $snippet, int $transportCount, int $incrementerCount): SettingsResult
     {
+        $recommended = '0 pending';
+
         // Both sources agree there's nothing pending → healthy.
         if ($transportCount === 0 && $incrementerCount === 0) {
             return SettingsResult::ok('queue', $snippet, '0 pending', $recommended);

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Components\Health\Checker\HealthChecker;
 
+use Doctrine\DBAL\Connection;
 use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
@@ -18,6 +19,8 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
 {
     private const URL = 'https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue';
 
+    private const DOCTRINE_TRANSPORT_CLASS = 'Symfony\\Component\\Messenger\\Bridge\\Doctrine\\Transport\\DoctrineTransport';
+
     /**
      * @param ServiceLocator<ReceiverInterface> $transportLocator
      */
@@ -27,6 +30,7 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         private readonly ServiceLocator $transportLocator,
         #[Autowire(service: 'shopware.increment.gateway.registry')]
         private readonly IncrementGatewayRegistry $incrementGatewayRegistry,
+        private readonly Connection $connection,
     ) {
     }
 
@@ -36,58 +40,53 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         $snippet = 'Open Queues';
         $recommended = \sprintf('max %d mins', $maxDiff);
 
-        // Two sources for "how much is pending":
-        //
-        //  1) messenger.receiver_locator → MessageCountAwareInterface. Source of truth
-        //     for the actual state of the configured transport backend(s) (Doctrine,
-        //     Redis, …).
-        //  2) shopware.increment.gateway.registry → "message_queue" pool, key
-        //     "message_queue_stats". Shopware increments this on dispatch and
-        //     decrements on handle. A stuck counter here (handler crashed before
-        //     decrement) is exactly the state the queue list tab surfaces but the
-        //     transport backend no longer reflects.
-        //
-        // Using the maximum of both makes the Open Queues row agree with the queue
-        // list tab: a stuck counter shows up as pending and can be cleared via the
-        // "Reset Queue" button in the admin.
-        [$transportCount, $hasCountableTransport] = $this->countPendingFromTransports();
+        [$transportCount, $hasCountableTransport, $hasDoctrineTransport] = $this->inspectTransports();
         $incrementerCount = $this->countPendingFromIncrementer();
-        $displayCount = max($transportCount, $incrementerCount);
 
-        if ($hasCountableTransport || $incrementerCount > 0) {
-            if ($displayCount === 0) {
-                $result = SettingsResult::ok('queue', $snippet, '0 pending', $recommended);
-            } else {
-                // We know the count but not the age of individual messages. A
-                // persistently non-zero count is the real stuck-queue signal; drill
-                // down via the queue list tab for per-message details.
-                $result = SettingsResult::ok('queue', $snippet, $displayCount . ' pending', $recommended);
-            }
-        } else {
-            // Neither the transport locator nor the incrementer gave us anything
-            // usable (e.g. pure AMQP setup with the increment pool disabled). We do
-            // NOT fall back to reading messenger_messages, because any rows there are
-            // almost certainly leftovers from a previous configuration and would
-            // produce a misleading warning.
-            $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
+        // 1) Doctrine is the active transport → we can reliably query messenger_messages
+        //    for the oldest pending message and restore the original "age in minutes"
+        //    display. The table is the source of truth while Doctrine is live; processed
+        //    messages get deleted, so any row we find is actually pending.
+        if ($hasDoctrineTransport) {
+            $result = $this->doctrineAgeBasedResult($snippet, $recommended, $maxDiff);
+            $result->url = self::URL;
+            $collection->add($result);
+
+            return;
         }
 
+        // 2) No Doctrine transport is active, but some count-capable transport is (Redis,
+        //    …) — or the Shopware increment gateway has data. Use a count-based display.
+        if ($hasCountableTransport || $incrementerCount > 0) {
+            $result = $this->countBasedResult($snippet, $recommended, $transportCount, $incrementerCount);
+            $result->url = self::URL;
+            $collection->add($result);
+
+            return;
+        }
+
+        // 3) Nothing usable (e.g. pure AMQP setup with the increment pool disabled). We
+        //    deliberately do NOT fall back to messenger_messages here, because without an
+        //    active Doctrine transport any rows we find there are almost certainly stale
+        //    leftovers from a previous configuration.
+        $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
         $result->url = self::URL;
         $collection->add($result);
     }
 
     /**
-     * @return array{int, bool} [totalCount, hasCountableTransport]
+     * @return array{int, bool, bool} [transportCount, hasCountableTransport, hasDoctrineTransport]
      */
-    private function countPendingFromTransports(): array
+    private function inspectTransports(): array
     {
         $totalCount = 0;
         $hasCountableTransport = false;
+        $hasDoctrineTransport = false;
 
         try {
             $providedServices = array_keys($this->transportLocator->getProvidedServices());
         } catch (\Throwable) {
-            return [0, false];
+            return [0, false, false];
         }
 
         foreach ($providedServices as $name) {
@@ -98,9 +97,14 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
             try {
                 $transport = $this->transportLocator->get($name);
             } catch (\Throwable) {
-                // A transport might fail to instantiate if its backend is temporarily
-                // unreachable — don't let that kill the whole health check.
+                // Backend unreachable or misconfigured transport — ignore and keep going.
                 continue;
+            }
+
+            // is_a() with a string class name returns false if the class isn't loaded,
+            // so this is safe even when symfony/doctrine-messenger isn't installed.
+            if (\is_a($transport, self::DOCTRINE_TRANSPORT_CLASS)) {
+                $hasDoctrineTransport = true;
             }
 
             if (!$transport instanceof MessageCountAwareInterface) {
@@ -116,7 +120,7 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
             }
         }
 
-        return [$totalCount, $hasCountableTransport];
+        return [$totalCount, $hasCountableTransport, $hasDoctrineTransport];
     }
 
     private function countPendingFromIncrementer(): int
@@ -137,5 +141,54 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         }
 
         return $total;
+    }
+
+    private function doctrineAgeBasedResult(string $snippet, string $recommended, int $maxDiff): SettingsResult
+    {
+        try {
+            /** @var string|false $oldestMessageAt */
+            $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages WHERE available_at < UTC_TIMESTAMP() ORDER BY available_at ASC LIMIT 1');
+        } catch (\Doctrine\DBAL\Exception) {
+            return SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
+        }
+
+        if (!\is_string($oldestMessageAt)) {
+            return SettingsResult::ok('queue', $snippet, '0 mins', $recommended);
+        }
+
+        $oldMessageLimit = (new \DateTimeImmutable())->modify(\sprintf('-%d minutes', $maxDiff));
+        $diff = round(abs(
+            ((new \DateTime($oldestMessageAt . ' UTC'))->getTimestamp() - $oldMessageLimit->getTimestamp()) / 60,
+        ));
+
+        if ($diff > $maxDiff) {
+            return SettingsResult::warning('queue', $snippet, $diff . ' mins', $recommended);
+        }
+
+        return SettingsResult::ok('queue', $snippet, $diff . ' mins', $recommended);
+    }
+
+    private function countBasedResult(string $snippet, string $recommended, int $transportCount, int $incrementerCount): SettingsResult
+    {
+        // Both sources agree there's nothing pending → healthy.
+        if ($transportCount === 0 && $incrementerCount === 0) {
+            return SettingsResult::ok('queue', $snippet, '0 pending', $recommended);
+        }
+
+        // Transport backend is empty but the Shopware incrementer still tracks something.
+        // This is the "stuck / in flight" state: a handler crashed before decrementing,
+        // or a long-running handler is currently holding the message. Surface it as INFO
+        // so the user knows it's not a clean "pending" state — they can investigate via
+        // the queue list tab (which uses the same incrementer) and clear it with the
+        // Reset Queue button.
+        if ($transportCount === 0 && $incrementerCount > 0) {
+            return SettingsResult::info('queue', $snippet, $incrementerCount . ' in flight', $recommended);
+        }
+
+        // Transport backend has messages → actively processing. A persistently non-zero
+        // count is the real stuck-worker signal; use the queue list tab for details.
+        $displayCount = max($transportCount, $incrementerCount);
+
+        return SettingsResult::ok('queue', $snippet, $displayCount . ' pending', $recommended);
     }
 }

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -9,12 +9,23 @@ use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 class QueueChecker implements HealthCheckerInterface, CheckerInterface
 {
+    private const URL = 'https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue';
+
+    /**
+     * @param ServiceLocator<ReceiverInterface> $transportLocator
+     */
     public function __construct(
         private readonly Connection $connection,
         private readonly SystemConfigService $configService,
+        #[Autowire(service: 'messenger.receiver_locator')]
+        private readonly ServiceLocator $transportLocator,
     ) {
     }
 
@@ -26,16 +37,14 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         $snippet = 'Open Queues';
         $recommended = \sprintf('max %d mins', $maxDiff);
 
-        /** @var string|false $oldestMessageAt */
+        // 1) Try the Doctrine path first — it gives the richest info (oldest message age).
+        //    If the messenger_messages table is missing or the query fails, fall through
+        //    to the transport-based path.
         try {
+            /** @var string|false $oldestMessageAt */
             $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages WHERE available_at < UTC_TIMESTAMP() ORDER BY available_at ASC LIMIT 1');
         } catch (\Doctrine\DBAL\Exception) {
-            // messenger_messages table is not present when the configured transport is not Doctrine
-            $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
-            $result->url = 'https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue';
-            $collection->add($result);
-
-            return;
+            $oldestMessageAt = false;
         }
 
         if (\is_string($oldestMessageAt)) {
@@ -48,11 +57,68 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
             } else {
                 $result = SettingsResult::ok('queue', $snippet, $diff . ' mins', $recommended);
             }
-        } else {
-            $result = SettingsResult::info('queue', $snippet, 'unknown', $recommended);
+            $result->url = self::URL;
+            $collection->add($result);
+
+            return;
         }
 
-        $result->url = 'https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue';
-        $collection->add($result);
+        // 2) Transport-based path: works for any transport that implements
+        //    MessageCountAwareInterface (Doctrine with empty table, Redis, …). AMQP does
+        //    not implement it in Symfony core and will fall through to the INFO default.
+        $collection->add($this->collectFromTransports($snippet, $recommended));
+    }
+
+    private function collectFromTransports(string $snippet, string $recommended): SettingsResult
+    {
+        $totalCount = 0;
+        $hasCountableTransport = false;
+
+        try {
+            $providedServices = array_keys($this->transportLocator->getProvidedServices());
+        } catch (\Throwable) {
+            $providedServices = [];
+        }
+
+        foreach ($providedServices as $name) {
+            if (!\is_string($name) || !str_starts_with($name, 'messenger.transport')) {
+                continue;
+            }
+
+            try {
+                $transport = $this->transportLocator->get($name);
+            } catch (\Throwable) {
+                // A transport might fail to instantiate if its backend is temporarily
+                // unreachable — don't let that kill the whole health check.
+                continue;
+            }
+
+            if (!$transport instanceof MessageCountAwareInterface) {
+                continue;
+            }
+
+            $hasCountableTransport = true;
+
+            try {
+                $totalCount += $transport->getMessageCount();
+            } catch (\Throwable) {
+                // Backend hiccup — skip this transport but keep going.
+            }
+        }
+
+        if (!$hasCountableTransport) {
+            $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
+        } elseif ($totalCount === 0) {
+            $result = SettingsResult::ok('queue', $snippet, '0 pending', $recommended);
+        } else {
+            // We know the count but not the age of individual messages, so a high count
+            // alone is not a reliable "stuck" signal. Report as OK and let the user drill
+            // down via the queue list tab if they want more detail.
+            $result = SettingsResult::ok('queue', $snippet, $totalCount . ' pending', $recommended);
+        }
+
+        $result->url = self::URL;
+
+        return $result;
     }
 }

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -27,7 +27,16 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         $recommended = \sprintf('max %d mins', $maxDiff);
 
         /** @var string|false $oldestMessageAt */
-        $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages WHERE available_at < UTC_TIMESTAMP() ORDER BY available_at ASC LIMIT 1');
+        try {
+            $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages WHERE available_at < UTC_TIMESTAMP() ORDER BY available_at ASC LIMIT 1');
+        } catch (\Doctrine\DBAL\Exception) {
+            // messenger_messages table is not present when the configured transport is not Doctrine
+            $result = SettingsResult::info('queue', $snippet, 'not monitorable', $recommended);
+            $result->url = 'https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue';
+            $collection->add($result);
+
+            return;
+        }
 
         if (\is_string($oldestMessageAt)) {
             $diff = round(abs(

--- a/src/Components/Health/Checker/HealthChecker/TaskChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/TaskChecker.php
@@ -54,14 +54,14 @@ class TaskChecker implements HealthCheckerInterface, CheckerInterface
             return;
         }
 
-        $maxTaskNextExecTime = 0;
+        $oldestTaskNextExecTime = \PHP_INT_MAX;
 
         foreach ($tasks as $task) {
-            $maxTaskNextExecTime = max((new \DateTimeImmutable($task['next_execution_time']))->getTimestamp(), $maxTaskNextExecTime);
+            $oldestTaskNextExecTime = min((new \DateTimeImmutable($task['next_execution_time']))->getTimestamp(), $oldestTaskNextExecTime);
         }
 
         $diff = round(abs(
-            ($maxTaskNextExecTime - $taskDateLimit->getTimestamp()) / 60,
+            ($oldestTaskNextExecTime - $taskDateLimit->getTimestamp()) / 60,
         ));
 
         $collection->add(SettingsResult::warning('scheduled_task', 'Scheduled tasks overdue', \sprintf('%d mins', $diff + $maxDiff), $recommended));

--- a/src/Components/Health/Checker/PerformanceChecker/QueueConnectionChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/QueueConnectionChecker.php
@@ -48,7 +48,19 @@ class QueueConnectionChecker implements PerformanceCheckerInterface, CheckerInte
                     $url,
                 ),
             );
+
+            return;
         }
+
+        $collection->add(
+            SettingsResult::ok(
+                $id,
+                'Queue adapter',
+                $schema,
+                'redis or rabbitmq',
+                $url,
+            ),
+        );
     }
 
     private function getSchema(): string

--- a/src/Controller/QueueController.php
+++ b/src/Controller/QueueController.php
@@ -52,7 +52,12 @@ class QueueController extends AbstractController
         $incrementer = $this->incrementer->get('message_queue');
         $incrementer->reset('message_queue_stats');
 
-        $this->connection->executeStatement('TRUNCATE `messenger_messages`');
+        try {
+            $this->connection->executeStatement('TRUNCATE `messenger_messages`');
+        } catch (\Doctrine\DBAL\Exception) {
+            // messenger_messages table is not present when the configured transport is not Doctrine
+        }
+
         $this->connection->executeStatement('UPDATE product_export SET is_running = 0');
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);


### PR DESCRIPTION
## Summary

- `QueueChecker` no longer assumes the Doctrine transport and works correctly with Redis Streams and AMQP setups
- `QueueController::resetQueue()` and `ElasticsearchManager::reset()` survive when the `messenger_messages` table is absent/unused
- `QueueConnectionChecker` finally shows the transport type for Redis/AMQP setups in the performance status (was a silent gap before)
- `TaskChecker` reports the *oldest* overdue task instead of the newest one (pre-existing bug)

Closes #393.

## Background

FroshTools's queue health and performance rows were hard-coded to read from the `messenger_messages` Doctrine table. On shops that migrated to Redis Streams or AMQP, this produced three visible problems:

1. **"Open Queues" showed bogus ages from leftover Doctrine-era rows** — e.g. `1261 min` on a healthy Redis setup, because the table still held rows from before the migration and nothing ever cleaned them up
2. **The performance-status tab had no messenger info at all** — `QueueConnectionChecker` emitted a row only for `doctrine`/`sync` schemes and silently did nothing for Redis/AMQP
3. **Queue reset and Elasticsearch reset executed `TRUNCATE/DELETE FROM messenger_messages` unconditionally** — which can throw on setups where the table is missing

The fix is transport-agnostic and reuses Symfony's `messenger.receiver_locator` + `MessageCountAwareInterface` — the same pattern `QueueController::getMessengerStats()` has been using successfully all along. For Doctrine users the original age-in-minutes display is preserved via an `is_a()` check against `DoctrineTransport`, so nothing regresses for them.

## What changed

| File | Change |
|---|---|
| `src/Components/Health/Checker/HealthChecker/QueueChecker.php` | Rewritten to inspect the transport locator and Shopware's `shopware.increment.gateway.registry`. Three code paths: Doctrine age-based (behaviour preserved), count-based for Redis and any other `MessageCountAwareInterface` transport, and "not monitorable" fallback for pure AMQP. Distinguishes the `transport=0 & incrementer>0` drift state as INFO "N in flight" so stuck counters are visible without being alarming. |
| `src/Components/Health/Checker/HealthChecker/TaskChecker.php` | Bug fix: used `max()` with init `0`, which reported the *newest* overdue task instead of the oldest. Changed to `min()` with `\PHP_INT_MAX` init. |
| `src/Components/Health/Checker/PerformanceChecker/QueueConnectionChecker.php` | Always emits a result row: warning for `doctrine`/`sync`, OK with the detected scheme for `redis`/`amqp`/others. Previously Redis/AMQP setups saw no messenger info at all in the performance status. |
| `src/Controller/QueueController.php` | `TRUNCATE messenger_messages` in `resetQueue()` wrapped in `try/catch \Doctrine\DBAL\Exception`. Increment-stats reset and `UPDATE product_export` still run unconditionally. |
| `src/Components/Elasticsearch/ElasticsearchManager.php` | `DELETE FROM messenger_messages WHERE body LIKE '%ElasticsearchIndexingMessage%'` in `reset()` wrapped in `try/catch`. No constructor change on purpose — the child class `DisabledElasticsearchManager` has an empty constructor and would break if new required parameters were added. |

## Behaviour matrix

| Transport / state | Before | After |
|---|---|---|
| Doctrine, messages present | `"N mins" / "max N mins"` | unchanged |
| Doctrine, empty table | `"unknown"` INFO | `"0 mins"` OK |
| Redis, healthy | bogus `"N min"` warning from stale rows, or `"unknown"` | `"0 pending" / "0 pending"` OK |
| Redis, stuck Shopware incrementer | bogus `"N min"` warning from stale rows | `"N in flight" / "0 pending"` INFO |
| Pure AMQP (no `MessageCountAwareInterface`) | `"unknown"` INFO | `"not monitorable" / "n/a"` INFO |
| Queue reset on Redis/AMQP | 500 on `TRUNCATE` | silent skip |
| Elasticsearch reset on Redis/AMQP | 500 on `DELETE` | silent skip |
| `QueueConnectionChecker` on Redis/AMQP | no row | OK row with detected scheme |
| Overdue tasks with mixed ages | age of the *newest* overdue task | age of the *oldest* overdue task |

## Explicitly NOT changed

- **No database schema changes.** The plugin has no `src/Migration/` directory. The branch never issues `ALTER`/`CREATE` statements and never writes data outside of the existing code paths in `resetQueue()` / `ElasticsearchManager::reset()`.
- **No service container wiring changes** outside of constructor injection in `QueueChecker`. No new compiler passes, no new tags, no new container parameters.
- **No admin JS or Vue component changes.** The Queue tab and System Status view consume the same JSON shape as before.
- **No new Composer dependencies.** All injected services (`messenger.receiver_locator`, `shopware.increment.gateway.registry`, `Connection`, `SystemConfigService`) are already provided by Shopware core.
- **Doctrine users see exactly the same Open Queues row as before.** The `is_a($transport, 'Symfony\\Component\\Messenger\\Bridge\\Doctrine\\Transport\\DoctrineTransport')` check routes active Doctrine transports into the unchanged `doctrineAgeBasedResult()` path. The `is_a()` call with a string class name is safe even when `symfony/doctrine-messenger` is not installed — it just returns `false`.

## Trade-off

For Doctrine users nothing changes. For count-based transports (Redis, future ones) we report message count instead of oldest-message age. A persistently non-zero count is the real stuck-worker signal anyway — the previous "age in minutes" metric was only meaningful when the worker was actually down, and the Queue list tab still exposes per-transport details for drill-down.

## Commit breakdown

```
ed20056 refactor: localize recommended label per QueueChecker path
49b6fb7 feat: distinguish in-flight state, restore Doctrine age display
14fdb82 fix: reconcile QueueChecker count with increment gateway (#393)
30a4b98 fix: QueueChecker must ignore stale messenger_messages rows (#393)
8f09104 feat: show Redis/AMQP queue counts in QueueChecker
c573e83 fix: defensive guards for non-Doctrine messenger transports (#393)
```

Each commit is independently reviewable; `c573e83` is a safe defensive baseline that can be merged alone if the rest raises concerns.

## Test plan

- [ ] Clean cache wipe before testing — **opcache retains old compiled classes**, so `bin/console cache:clear` alone is not enough:
  ```bash
  rm -rf var/cache/*
  bin/console cache:clear
  sudo systemctl reload php*-fpm
  ```
- [ ] **Doctrine backend** — FroshTools → System Status → "Open Queues" still shows `"N mins" / "max N mins"` (no regression)
- [ ] **Redis backend, healthy** — FroshTools → System Status → "Open Queues" shows `"0 pending" / "0 pending"` OK
- [ ] **Redis backend with a stuck `message_queue_stats` incrementer** — "Open Queues" shows `"N in flight" / "0 pending"` INFO (distinguishable from the healthy state)
- [ ] **Performance Status** — a "Queue adapter" row with the detected scheme (`redis`, `amqp`, …) is present for non-doctrine setups
- [ ] **Queue tab → Reset Queue** on a Redis/AMQP setup — returns 204, no DBAL exception in `var/log/*.log`
- [ ] **Elasticsearch reset** on a Redis-configured store — no 500 error on `DELETE FROM messenger_messages`
- [ ] **Scheduled tasks overdue** row — when multiple tasks are overdue, the displayed age matches the *oldest* overdue task, not the newest
- [ ] **Pure AMQP (if available)** — "Open Queues" shows `"not monitorable" / "n/a"` INFO, no crash

## References

- Fixes FriendsOfShopware/FroshTools#393
- User-facing journey during development: transport-aware refactor → admin lockup from unrelated opcache state → rollback to `main` → clean restart with the incremental approach this branch now contains
- Related investigation: a "stuck" `CollectEntityDataMessage` in Shopware's `message_queue_stats` incrementer (reproducible on the reporter's Redis setup) is a Shopware-core drift artefact outside FroshTools's scope. This PR makes the state *visible* via the new INFO "in flight" label but does not attempt to fix the upstream drift.