### PR TITLE
Refactor Elasticsearch indices retrieval to use explicit patterns

### DIFF
--- a/src/Components/Elasticsearch/ElasticsearchManager.php
+++ b/src/Components/Elasticsearch/ElasticsearchManager.php
@@ -56,24 +56,27 @@ class ElasticsearchManager
      */
     public function indices(): array
     {
-        $indices = $this->client->indices()->get(['index' => '*']);
-        $stats = $this->client->indices()->stats(['index' => '*']);
+        $patterns = [
+            $this->indexPrefix . '_*',
+            $this->adminIndexPrefix . '-*',
+        ];
 
         $list = [];
 
-        foreach ($indices as $indexName => $config) {
-            if (!$this->matchesPrefix($indexName)) {
-                continue;
+        foreach ($patterns as $pattern) {
+            $indices = $this->client->indices()->get(['index' => $pattern]);
+            $stats = $this->client->indices()->stats(['index' => $pattern]);
+
+            foreach ($indices as $indexName => $config) {
+                $statCfg = $stats['indices'][$indexName];
+
+                $list[] = [
+                    'name' => $indexName,
+                    'aliases' => array_keys($config['aliases']),
+                    'indexSize' => $statCfg['total']['store']['size_in_bytes'],
+                    'docs' => $statCfg['primaries']['docs']['count'],
+                ];
             }
-
-            $statCfg = $stats['indices'][$indexName];
-
-            $list[] = [
-                'name' => $indexName,
-                'aliases' => array_keys($config['aliases']),
-                'indexSize' => $statCfg['total']['store']['size_in_bytes'],
-                'docs' => $statCfg['primaries']['docs']['count'],
-            ];
         }
 
         return $list;


### PR DESCRIPTION
## Summary
Refactored the `indices()` method in ElasticsearchManager to query Elasticsearch using explicit index patterns instead of fetching all indices and filtering them in PHP.

## Key Changes
- Replaced wildcard query for all indices (`*`) with explicit pattern-based queries using `indexPrefix` and `adminIndexPrefix`
- Moved prefix matching logic from PHP-level filtering (`matchesPrefix()` check) to Elasticsearch query patterns
- Restructured the method to iterate over patterns and query each pattern separately, then process results
- Removed the now-unnecessary `matchesPrefix()` filtering logic

## Implementation Details
- Two patterns are now queried: `{indexPrefix}_*` and `{adminIndexPrefix}-*`
- Each pattern is queried independently for both indices configuration and statistics
- Results are accumulated into a single list, maintaining the same output structure
- This approach reduces data transfer and processing by filtering at the Elasticsearch level rather than in application code

https://claude.ai/code/session_012j1CvFd4QhSMHwVgLVowBd