### PR TITLE
feat: add logsEnabled flag based on log folder existence

### DIFF
--- a/src/Controller/LogController.php
+++ b/src/Controller/LogController.php
@@ -96,6 +96,10 @@ class LogController extends AbstractController
      */
     private function getFiles(): array
     {
+        if (!is_dir($this->logDir)) {
+            return [];
+        }
+
         $finder = new Finder();
         $finder
             ->in($this->logDir)

--- a/src/Resources/app/administration/src/module/frosh-tools/page/index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/page/index/index.js
@@ -27,6 +27,19 @@ Component.register('frosh-tools-index', {
                 );
             }
         },
+        logsAvailable() {
+            try {
+                return (
+                    Shopware.Store.get('context').app.config.settings
+                        ?.froshTools.logsEnabled || false
+                );
+            } catch {
+                return (
+                    Shopware.State.get('context').app.config.settings
+                        ?.froshTools.logsEnabled || false
+                );
+            }
+        },
         elasticsearchAvailable() {
             try {
                 return (

--- a/src/Resources/app/administration/src/module/frosh-tools/page/index/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/page/index/template.twig
@@ -16,7 +16,10 @@
             <sw-tabs-item :route="{ name: 'frosh.tools.index.queue' }">
                 {{ $t('frosh-tools.tabs.queue.title') }}
             </sw-tabs-item>
-            <sw-tabs-item :route="{ name: 'frosh.tools.index.logs' }">
+            <sw-tabs-item
+                :route="{ name: 'frosh.tools.index.logs' }"
+                v-if="logsAvailable"
+            >
                 {{ $t('frosh-tools.tabs.logs.title') }}
             </sw-tabs-item>
             <sw-tabs-item

--- a/src/Subscriber/AdminInfoListener.php
+++ b/src/Subscriber/AdminInfoListener.php
@@ -11,6 +11,8 @@ class AdminInfoListener
     public function __construct(
         #[Autowire('%frosh_tools.elasticsearch.enabled%')]
         private bool $elasticsearchEnabled,
+        #[Autowire(param: 'kernel.logs_dir')]
+        private readonly string $logDir,
         #[Autowire(param: 'shopware.http_cache.reverse_proxy.fastly.service_id')]
         private readonly ?string $fastlyServiceId = null,
     ) {
@@ -29,6 +31,7 @@ class AdminInfoListener
 
         $data['settings']['froshTools'] = [
             'elasticsearchEnabled' => $this->elasticsearchEnabled,
+            'logsEnabled' => is_dir($this->logDir),
             'fastlyEnabled' => !empty($this->fastlyServiceId),
         ];
 


### PR DESCRIPTION
## Summary

- Adds a `logsEnabled` flag to the AdminInfoListener that checks if the `kernel.logs_dir` directory actually exists (using `is_dir()`)
- Hides the Logs UI tab when the log directory does not exist, following the same pattern as the Elasticsearch and Fastly tabs
- Guards `LogController::getFiles()` against missing log directory to prevent `DirectoryNotFoundException`

## Changes

| File | Change |
|------|--------|
| `AdminInfoListener.php` | Added `logDir` parameter + `logsEnabled` flag via `is_dir()` |
| `index.js` | Added `logsAvailable` computed property |
| `template.twig` | Added `v-if="logsAvailable"` on logs tab |
| `LogController.php` | Added `is_dir()` check in `getFiles()` |