### PR TITLE
fix: skip root package in Composer audit collection

### DIFF
--- a/src/Components/ComposerAudit/ComposerAuditService.php
+++ b/src/Components/ComposerAudit/ComposerAuditService.php
@@ -163,9 +163,10 @@ class ComposerAuditService
     private function collectInstalledPackages(): array
     {
         $packages = [];
+        $rootPackageName = InstalledVersions::getRootPackage()['name'];
 
         foreach (InstalledVersions::getInstalledPackages() as $package) {
-            if ($package === '') {
+            if ($package === '' || $package === $rootPackageName) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- Skip the root package when collecting installed packages for the Composer audit
- Prevents unnecessary self-auditing entries in the audit results

## Test plan

- [ ] Verify the root package is no longer listed in Composer audit results
- [ ] Confirm other installed packages are still audited correctly