### PR TITLE
fix: wrap long log messages in detail modal

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-logs/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-logs/style.scss
@@ -29,9 +29,9 @@
         color: var(--ft-text-muted);
     }
 
-    &__message {
+    &__message.ft-diff {
         white-space: pre-wrap;
         overflow-wrap: anywhere;
-        max-height: 50vh;
+        max-height: none;
     }
 }


### PR DESCRIPTION
## Problem

Long exception lines in the log detail modal overflowed horizontally (showing a scrollbar) instead of wrapping within the modal width.

The message `<pre>` uses the shared `.ft-diff` class, which sets `white-space: pre`. The component's `.frosh-tab-logs__message` override (`pre-wrap` + `overflow-wrap: anywhere`) has equal specificity, so it only won depending on stylesheet load order — and `.ft-diff` was winning.

## Fix

- Compound the selector (`&__message.ft-diff`) so the wrap rules reliably win regardless of load order.
- Drop the nested `max-height: 50vh` cap so the modal body handles vertical scrolling on its own, instead of fighting with a nested scroll region.

## Before / After
Before: long lines scroll horizontally and clip.
After: lines wrap to the modal width; the modal body scrolls vertically when content exceeds height.