### PR TITLE
feat: track composer dependencies across all autoloaders

### DIFF
--- a/src/Components/ComposerAudit/ComposerAuditService.php
+++ b/src/Components/ComposerAudit/ComposerAuditService.php
@@ -102,22 +102,23 @@ class ComposerAuditService
                         continue;
                     }
 
-                    $installed = $packages[$packageName] ?? null;
-                    $prettyVersion = $installed['pretty'] ?? null;
-                    $normalizedVersion = $installed['normalized'] ?? null;
+                    // The same package may be installed at several versions across vendor dirs;
+                    // audit each version on its own so we only flag the ones actually affected.
+                    foreach ($packages[$packageName] ?? [] as $installed) {
+                        foreach ($packageAdvisories as $advisory) {
+                            $advisory = \is_array($advisory) ? $advisory : [];
 
-                    foreach ($packageAdvisories as $advisory) {
-                        $advisory = \is_array($advisory) ? $advisory : [];
+                            if (!$this->affectsInstalledVersion($installed['normalized'], $advisory)) {
+                                continue;
+                            }
 
-                        if (!$this->affectsInstalledVersion($normalizedVersion, $advisory)) {
-                            continue;
+                            $advisories[] = $this->normalizeAdvisory(
+                                (string) $packageName,
+                                $installed['pretty'],
+                                $installed['sources'],
+                                $advisory,
+                            );
                         }
-
-                        $advisories[] = $this->normalizeAdvisory(
-                            (string) $packageName,
-                            $prettyVersion,
-                            $advisory,
-                        );
                     }
                 }
             }
@@ -158,33 +159,55 @@ class ComposerAuditService
     }
 
     /**
-     * @return array<string, array{pretty: string, normalized: string|null}>
+     * Collects every installed package across all Composer datasets.
+     *
+     * Plugins can ship their own autoloader and register an additional dataset with
+     * InstalledVersions. The aggregate methods (getInstalledPackages/getRootPackage/...)
+     * merge across all of them, which mixes the plugin's dependency tree into the root and
+     * collapses the same package to a single version. getAllRawData() lets us read each
+     * dataset on its own, so we can keep distinct versions apart and remember which roots
+     * shipped each one — a plugin bundling an outdated, vulnerable copy stays visible even
+     * when the project root is already patched.
+     *
+     * The result is keyed by package name, then by pretty version, so each distinct
+     * (package, version) pair is audited on its own with the list of sources that ship it.
+     *
+     * @return array<string, array<string, array{pretty: string, normalized: string|null, sources: list<string>}>>
      */
     private function collectInstalledPackages(): array
     {
         $packages = [];
-        $rootPackageName = InstalledVersions::getRootPackage()['name'];
 
-        foreach (InstalledVersions::getInstalledPackages() as $package) {
-            if ($package === '' || $package === $rootPackageName) {
-                continue;
+        foreach (InstalledVersions::getAllRawData() as $index => $dataset) {
+            $rootPackageName = $dataset['root']['name'];
+
+            // The first dataset is the project itself; every other dataset is registered by a
+            // plugin shipping its own vendor dir. Label the project explicitly, plugins by name.
+            $source = $index === 0 ? 'project' : $rootPackageName;
+
+            foreach ($dataset['versions'] as $package => $info) {
+                if ($package === '' || $package === 'shopware/production') {
+                    continue;
+                }
+
+                // Replaced/provided packages have no version of their own.
+                $prettyVersion = $info['pretty_version'] ?? null;
+                if ($prettyVersion === null || $prettyVersion === '') {
+                    continue;
+                }
+
+                if (!isset($packages[$package][$prettyVersion])) {
+                    $packages[$package][$prettyVersion] = [
+                        'pretty' => $prettyVersion,
+                        'normalized' => $info['version'] ?? null,
+                        'sources' => [],
+                    ];
+                }
+
+                if (!\in_array($source, $packages[$package][$prettyVersion]['sources'], true)) {
+                    $packages[$package][$prettyVersion]['sources'][] = $source;
+                }
             }
-
-            try {
-                $prettyVersion = InstalledVersions::getPrettyVersion($package);
-                $normalizedVersion = InstalledVersions::getVersion($package);
-            } catch (\OutOfBoundsException) {
-                continue;
-            }
-
-            if ($prettyVersion === null || $prettyVersion === '') {
-                continue;
-            }
-
-            $packages[$package] = [
-                'pretty' => $prettyVersion,
-                'normalized' => $normalizedVersion,
-            ];
         }
 
         return $packages;
@@ -267,15 +290,17 @@ class ComposerAuditService
     }
 
     /**
+     * @param list<string> $sources
      * @param array<string, mixed> $advisory
      *
      * @return array<string, mixed>
      */
-    private function normalizeAdvisory(string $packageName, ?string $installedVersion, array $advisory): array
+    private function normalizeAdvisory(string $packageName, ?string $installedVersion, array $sources, array $advisory): array
     {
         return [
             'packageName' => $packageName,
             'installedVersion' => $installedVersion,
+            'installedSources' => $sources,
             'advisoryId' => isset($advisory['advisoryId']) ? (string) $advisory['advisoryId'] : null,
             'cve' => isset($advisory['cve']) ? (string) $advisory['cve'] : null,
             'title' => isset($advisory['title']) ? (string) $advisory['title'] : '',

--- a/src/Components/Health/Checker/HealthChecker/MultipleAutoloaderChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/MultipleAutoloaderChecker.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\Health\Checker\HealthChecker;
+
+use Composer\InstalledVersions;
+use Frosh\Tools\Components\Health\Checker\CheckerInterface;
+use Frosh\Tools\Components\Health\HealthCollection;
+use Frosh\Tools\Components\Health\SettingsResult;
+
+/**
+ * Warns when more than one Composer autoloader is registered in the process.
+ *
+ * Plugins that ship their own `vendor/` directory register an additional autoloader and
+ * an additional InstalledVersions dataset. That causes duplicate copies of dependencies to
+ * be loaded, breaks Composer's version tracking (the aggregate InstalledVersions methods
+ * merge or shadow each other), and can lead to subtle "class already declared" or
+ * wrong-version bugs that are hard to diagnose.
+ */
+class MultipleAutoloaderChecker implements HealthCheckerInterface, CheckerInterface
+{
+    private const ID = 'multiple-autoloaders';
+    private const SNIPPET = 'Composer autoloaders';
+    private const DOCS_URL = 'https://developer.shopware.com/docs/guides/plugins/plugins/dependencies/using-composer-dependencies.html';
+
+    public function collect(HealthCollection $collection): void
+    {
+        // The same project autoloader can be registered more than once (e.g. shopware/platform
+        // loaded via two vendor paths), which produces duplicate datasets that point at the same
+        // directory. Those are harmless, so we dedupe by the resolved root install path and only
+        // treat a genuinely different directory as an additional autoloader.
+        $datasets = $this->uniqueByInstallPath(InstalledVersions::getAllRawData());
+
+        if (\count($datasets) < 2) {
+            $collection->add(
+                SettingsResult::ok(self::ID, self::SNIPPET, 'single autoloader'),
+            );
+
+            return;
+        }
+
+        $roots = [];
+        foreach ($datasets as $dataset) {
+            $name = $dataset['root']['name'];
+            $roots[] = $name !== '' && $name !== '__root__' ? $name : $dataset['root']['install_path'];
+        }
+
+        $duplicates = $this->collectDuplicatePackages($datasets);
+
+        $current = \sprintf(
+            '%d autoloaders registered: %s',
+            \count($datasets),
+            implode(', ', $roots),
+        );
+
+        if ($duplicates !== []) {
+            $current .= \sprintf('; duplicate packages: %s', implode(', ', $duplicates));
+        }
+
+        $collection->add(
+            SettingsResult::warning(
+                self::ID,
+                self::SNIPPET,
+                $current,
+                'remove bundled vendor directories so only the project autoloader is used. Contact plugin authors if you are unsure how to do this.',
+                self::DOCS_URL,
+            ),
+        );
+    }
+
+    /**
+     * Collapses datasets that resolve to the same root install path — the same autoloader
+     * registered multiple times is not a real duplicate.
+     *
+     * @param list<array{root: array{name: string, install_path: string}, versions: array<string, array{pretty_version?: string}>}> $datasets
+     *
+     * @return list<array{root: array{name: string, install_path: string}, versions: array<string, array{pretty_version?: string}>}>
+     */
+    private function uniqueByInstallPath(array $datasets): array
+    {
+        $unique = [];
+        foreach ($datasets as $dataset) {
+            $path = $dataset['root']['install_path'];
+            $resolved = realpath($path);
+            $key = $resolved !== false ? $resolved : $path;
+
+            $unique[$key] ??= $dataset;
+        }
+
+        return array_values($unique);
+    }
+
+    /**
+     * Returns packages that are installed by more than one dataset, formatted as
+     * "package (versionA, versionB)". These are the dependencies that get loaded twice and
+     * are no longer tracked reliably.
+     *
+     * @param list<array{root: array{name: string, install_path: string}, versions: array<string, array{pretty_version?: string}>}> $datasets
+     *
+     * @return list<string>
+     */
+    private function collectDuplicatePackages(array $datasets): array
+    {
+        /** @var array<string, array{count: int, versions: array<string, true>}> $seen */
+        $seen = [];
+
+        foreach ($datasets as $dataset) {
+            $rootName = $dataset['root']['name'];
+
+            foreach ($dataset['versions'] as $package => $info) {
+                if ($package === '' || $package === $rootName) {
+                    continue;
+                }
+
+                $version = $info['pretty_version'] ?? null;
+                if ($version === null || $version === '') {
+                    continue;
+                }
+
+                $seen[$package] ??= ['count' => 0, 'versions' => []];
+                ++$seen[$package]['count'];
+                $seen[$package]['versions'][$version] = true;
+            }
+        }
+
+        $duplicates = [];
+        foreach ($seen as $package => $data) {
+            if ($data['count'] < 2) {
+                continue;
+            }
+
+            $duplicates[] = \sprintf('%s (%s)', $package, implode(', ', array_keys($data['versions'])));
+        }
+
+        sort($duplicates);
+
+        return $duplicates;
+    }
+}

--- a/src/Components/Security/Checker/DependencyAuditChecker.php
+++ b/src/Components/Security/Checker/DependencyAuditChecker.php
@@ -71,7 +71,7 @@ class DependencyAuditChecker implements SecurityCheckerInterface
             }
 
             $collection->add(new SecurityFinding(
-                'composer-audit-' . md5($packageName . '|' . (string) ($advisory['advisoryId'] ?? $title)),
+                'composer-audit-' . md5($packageName . '|' . $installedVersion . '|' . (string) ($advisory['advisoryId'] ?? $title)),
                 SecurityFinding::CATEGORY_DEPENDENCIES,
                 $this->mapSeverity((string) ($advisory['severity'] ?? '')),
                 $title !== '' ? $title : 'Security advisory',

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/index.js
@@ -40,14 +40,18 @@ Component.register('frosh-tools-security-dependencies', {
         groupedAdvisories() {
             const groups = {};
             for (const advisory of this.result.advisories || []) {
-                if (!groups[advisory.packageName]) {
-                    groups[advisory.packageName] = {
+                // The same package can be installed at different versions across vendor
+                // dirs (project root vs. a plugin's bundled copy), so group by both.
+                const key = `${advisory.packageName}@${advisory.installedVersion || ''}`;
+                if (!groups[key]) {
+                    groups[key] = {
                         packageName: advisory.packageName,
                         installedVersion: advisory.installedVersion,
+                        sources: advisory.installedSources || [],
                         advisories: [],
                     };
                 }
-                groups[advisory.packageName].advisories.push(advisory);
+                groups[key].advisories.push(advisory);
             }
             return Object.values(groups);
         },
@@ -134,6 +138,13 @@ Component.register('frosh-tools-security-dependencies', {
                 );
             }
             return severity.charAt(0).toUpperCase() + severity.slice(1);
+        },
+
+        sourceLabel(source) {
+            if (source === 'project') {
+                return this.$t('frosh-tools.tabs.composerAudit.sourceProject');
+            }
+            return source;
         },
 
         openUrl(url) {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/style.scss
@@ -122,6 +122,13 @@
     border-radius: var(--ft-radius-sm);
 }
 
+.frosh-security-dependencies__group-sources {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
 .frosh-security-dependencies__advisories {
     list-style: none;
     padding: 0;

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
@@ -64,8 +64,8 @@
         <p class="frosh-security-dependencies__howto-warning">
                             <ft-icon name="alert"/>
                             <span>
-            {{ $t('frosh-tools.tabs.composerAudit.howto.backup') }}
-        </span>
+    {{ $t('frosh-tools.tabs.composerAudit.howto.backup') }}
+</span>
         </p>
         <ol class="frosh-security-dependencies__howto">
             <li class="frosh-security-dependencies__howto-step">
@@ -118,8 +118,8 @@
         <p class="frosh-security-dependencies__howto-note">
                             <ft-icon name="info"/>
                             <span>
-            {{ $t('frosh-tools.tabs.composerAudit.howto.note') }}
-        </span>
+    {{ $t('frosh-tools.tabs.composerAudit.howto.note') }}
+</span>
         </p>
     </ft-panel>
     <ft-panel
@@ -182,6 +182,17 @@
                             v-if="group.installedVersion"
                             class="frosh-security-dependencies__group-version ft-mono"
                         >{{ group.installedVersion }}</span>
+                        <span
+                            v-if="group.sources && group.sources.length"
+                            class="frosh-security-dependencies__group-sources"
+                        >
+                            <ft-pill
+                                v-for="src in group.sources"
+                                :key="src"
+                                :variant="src === 'project' ? 'muted' : 'warning'"
+                                bare
+                            >{{ sourceLabel(src) }}</ft-pill>
+                        </span>
                     </div>
                     <span class="ft-panel__count">{{ group.advisories.length }}</span>
                 </div>

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -138,6 +138,7 @@
                 "affected": "Betroffene Versionen",
                 "reportedAt": "Gemeldet am",
                 "severityUnknown": "Unbekannt",
+                "sourceProject": "Projekt",
                 "howto": {
                     "title": "So beheben Sie diese Advisories",
                     "backup": "Erstellen Sie immer ein vollständiges Backup (Datenbank und Dateien), bevor Sie Abhängigkeiten aktualisieren, damit Sie zurückrollen können, falls ein Update Ihren Shop beschädigt.",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -138,6 +138,7 @@
                 "affected": "Affected versions",
                 "reportedAt": "Reported",
                 "severityUnknown": "Unknown",
+                "sourceProject": "Project",
                 "howto": {
                     "title": "How to fix these advisories",
                     "backup": "Always create a full backup (database and files) before updating dependencies, so you can roll back if an update breaks your shop.",


### PR DESCRIPTION
## What

Plugins can ship their own `vendor/` directory and register an additional Composer autoloader, which interferes with Composer's runtime version tracking. The aggregate `InstalledVersions` methods (`getInstalledPackages()`, `getRootPackage()`, `getPrettyVersion()`, `getVersion()`) merge or shadow across every registered dataset, so the composer audit could pick the wrong root and collapse duplicate copies of a dependency into one.

## Changes

- **Composer audit reads `InstalledVersions::getAllRawData()`** — walks every dataset on its own instead of the aggregate methods. Each distinct `(package, version)` pair is now audited separately and carries the list of sources (`project` or the plugin's composer root name) that ship it. A plugin bundling an outdated, vulnerable copy stays visible even when the project root is already patched.
- **Reporting surfaces the source** — the security dependencies UI groups advisories by `package@version` and shows a source pill per group (project vs. plugin), with `sourceProject` snippets (en/de). `DependencyAuditChecker` now includes the installed version in its finding ID so two versions of the same package don't collapse into one finding.
- **New `MultipleAutoloaderChecker` health check** — warns when more than one autoloader is registered (deduped by resolved install path, so the same project loaded twice is not flagged), listing the responsible roots and any duplicated dependencies. Links to the [Shopware docs on using composer dependencies](https://developer.shopware.com/docs/guides/plugins/plugins/dependencies/using-composer-dependencies.html) and hints to contact plugin authors.

## Testing

- `shopware-cli extension validate --full .` → 0 problems
- `shopware-cli extension format .` applied
- PHPStan clean on all touched PHP files