### PR TITLE
fix: restore Elasticsearch cluster status display and detect OpenSearch

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/index.js
@@ -27,6 +27,39 @@ Component.register('frosh-tools-tab-elasticsearch', {
         };
     },
 
+    computed: {
+        engineName() {
+            return this.statusInfo.info?.version?.distribution === 'opensearch'
+                ? 'OpenSearch'
+                : 'Elasticsearch';
+        },
+
+        engineVersion() {
+            return this.statusInfo.info?.version?.number ?? null;
+        },
+
+        clusterHealth() {
+            return this.statusInfo.health?.status ?? null;
+        },
+
+        healthVariant() {
+            switch (this.clusterHealth) {
+                case 'green':
+                    return 'success';
+                case 'yellow':
+                    return 'warning';
+                case 'red':
+                    return 'danger';
+                default:
+                    return null;
+            }
+        },
+
+        nodeCount() {
+            return this.statusInfo.health?.number_of_nodes ?? null;
+        },
+    },
+
     created() {
         this.createdComponent();
     },

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/style.scss
@@ -1,4 +1,24 @@
 .frosh-tab-es {
+    &__status-bar {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 8px 16px;
+        margin-bottom: 16px;
+    }
+
+    &__status-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    &__status-label {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--ft-text-soft);
+    }
+
     &__name {
         display: flex;
         align-items: center;

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/template.twig
@@ -1,6 +1,6 @@
 <div class="ft frosh-tab-es">
     <ft-page-head
-        :title="$t('frosh-tools.tabs.elasticsearch.title')"
+        :title="engineName"
         subtitle="Cluster status, indices and a low-level query console."
     >
         <template
@@ -22,12 +22,44 @@
         <ft-hero-state
             variant="danger"
             icon="alert"
-            title="Elasticsearch is not enabled"
+            :title="engineName + ' is not enabled'"
             :body="$t('frosh-tools.tabs.elasticsearch.disabled')"
         />
     </template>
 
     <template v-else>
+        <div
+            v-if="engineVersion || clusterHealth || nodeCount !== null"
+            class="frosh-tab-es__status-bar"
+        >
+            <div
+                v-if="engineVersion"
+                class="frosh-tab-es__status-item"
+            >
+                <span class="frosh-tab-es__status-label">
+                    {{ $t('frosh-tools.tabs.elasticsearch.version') }}
+                </span>
+                <ft-pill variant="info">{{ engineVersion }}</ft-pill>
+            </div>
+            <div
+                v-if="nodeCount !== null"
+                class="frosh-tab-es__status-item"
+            >
+                <span class="frosh-tab-es__status-label">
+                    {{ $t('frosh-tools.tabs.elasticsearch.nodes') }}
+                </span>
+                <ft-pill variant="info">{{ nodeCount }}</ft-pill>
+            </div>
+            <div
+                v-if="clusterHealth"
+                class="frosh-tab-es__status-item"
+            >
+                <span class="frosh-tab-es__status-label">
+                    {{ $t('frosh-tools.tabs.elasticsearch.status') }}
+                </span>
+                <ft-pill :variant="healthVariant">{{ clusterHealth }}</ft-pill>
+            </div>
+        </div>
         <ft-panel
             :title="$t('frosh-tools.tabs.elasticsearch.indices')"
             :count="indices ? indices.length : 0"
@@ -175,7 +207,9 @@
                 </table>
             </div>
         </ft-panel>
-        <ft-panel :title="$t('frosh-tools.tabs.elasticsearch.console.title')">
+        <ft-panel
+            :title="engineName + ' ' + $t('frosh-tools.tabs.elasticsearch.console.title')"
+        >
             <template #actions>
                 <button
                     class="ft-btn ft-btn--primary"

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -31,9 +31,9 @@
                 }
             },
             "elasticsearch": {
-                "title": "Elasticsearch",
-                "disabled": "Elasticsearch ist nicht aktiviert",
-                "version": "Elasticsearch version",
+                "title": "Search",
+                "disabled": "Search ist nicht aktiviert",
+                "version": "Version",
                 "nodes": "Nodes",
                 "status": "Cluster Status",
                 "indices": "Indizes",
@@ -44,7 +44,7 @@
                     "showUnused": "Ungenutzte Indizes anzeigen",
                     "cleanup": "Ungenutzte Indizes löschen",
                     "cleanupOrphaned": "Verwaiste Indizes löschen",
-                    "reset": "Elasticsearch zurücksetzen"
+                    "reset": "Search zurücksetzen"
                 },
                 "badge": {
                     "shopware": "Shopware",
@@ -75,7 +75,7 @@
                     }
                 },
                 "console": {
-                    "title": "Elasticsearch Konsole",
+                    "title": "Konsole",
                     "send": "Senden",
                     "output": "Ausgabe"
                 }

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -31,9 +31,9 @@
                 }
             },
             "elasticsearch": {
-                "title": "Elasticsearch",
-                "disabled": "Elasticsearch is not enabled",
-                "version": "Elasticsearch version",
+                "title": "Search",
+                "disabled": "Search is not enabled",
+                "version": "Version",
                 "nodes": "Nodes",
                 "status": "Cluster Status",
                 "indices": "Indices",
@@ -44,7 +44,7 @@
                     "showUnused": "Show unused indices",
                     "cleanup": "Delete unused indices",
                     "cleanupOrphaned": "Delete orphaned indices",
-                    "reset": "Reset Elasticsearch"
+                    "reset": "Reset Search"
                 },
                 "badge": {
                     "shopware": "Shopware",
@@ -75,7 +75,7 @@
                     }
                 },
                 "console": {
-                    "title": "Elasticsearch Console",
+                    "title": "Console",
                     "send": "Send",
                     "output": "Output"
                 }


### PR DESCRIPTION
## Summary

Fixes #420

### Changes

- **Re-added cluster status display** — version, node count, and cluster health now render as `ft-pill` components in a status bar above the indices panel
- **OpenSearch detection** — detects `version.distribution === 'opensearch'` and labels the engine correctly (OpenSearch vs Elasticsearch) throughout the UI
- **Engine-neutral snippets** — replaced hardcoded "Elasticsearch" with "Search" in translations; the dynamic `engineName` computed property provides the correct engine label where needed
- **Health color mapping** — cluster health `green`/`yellow`/`red` maps to `success`/`warning`/`danger` pill variants

### Files changed
- `index.js` — 5 computed properties (`engineName`, `engineVersion`, `clusterHealth`, `healthVariant`, `nodeCount`)
- `template.twig` — dynamic page title, status bar, dynamic disabled/console titles
- `style.scss` — status bar flexbox layout styles
- `en-GB.json` / `de-DE.json` — engine-neutral snippet values