### PR TITLE
fix: use parameterized i18n for elasticsearch/opensearch titles

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
@@ -62,10 +62,10 @@
         :title="$t('frosh-tools.tabs.composerAudit.howto.title')"
     >
         <p class="frosh-security-dependencies__howto-warning">
-                            <ft-icon name="alert"/>
-                            <span>
-    {{ $t('frosh-tools.tabs.composerAudit.howto.backup') }}
-</span>
+                                            <ft-icon name="alert"/>
+                                            <span>
+            {{ $t('frosh-tools.tabs.composerAudit.howto.backup') }}
+        </span>
         </p>
         <ol class="frosh-security-dependencies__howto">
             <li class="frosh-security-dependencies__howto-step">
@@ -116,10 +116,10 @@
             </li>
         </ol>
         <p class="frosh-security-dependencies__howto-note">
-                            <ft-icon name="info"/>
-                            <span>
-    {{ $t('frosh-tools.tabs.composerAudit.howto.note') }}
-</span>
+                                            <ft-icon name="info"/>
+                                            <span>
+            {{ $t('frosh-tools.tabs.composerAudit.howto.note') }}
+        </span>
         </p>
     </ft-panel>
     <ft-panel

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/template.twig
@@ -22,7 +22,7 @@
         <ft-hero-state
             variant="danger"
             icon="alert"
-            :title="engineName + ' is not enabled'"
+            :title="$t('frosh-tools.tabs.elasticsearch.disabledTitle', { engine: engineName })"
             :body="$t('frosh-tools.tabs.elasticsearch.disabled')"
         />
     </template>
@@ -208,7 +208,7 @@
             </div>
         </ft-panel>
         <ft-panel
-            :title="engineName + ' ' + $t('frosh-tools.tabs.elasticsearch.console.title')"
+            :title="$t('frosh-tools.tabs.elasticsearch.console.title', { engine: engineName })"
         >
             <template #actions>
                 <button

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -33,6 +33,7 @@
             "elasticsearch": {
                 "title": "Search",
                 "disabled": "Search ist nicht aktiviert",
+                "disabledTitle": "{engine} ist nicht aktiviert",
                 "version": "Version",
                 "nodes": "Nodes",
                 "status": "Cluster Status",
@@ -75,7 +76,7 @@
                     }
                 },
                 "console": {
-                    "title": "Konsole",
+                    "title": "{engine} Konsole",
                     "send": "Senden",
                     "output": "Ausgabe"
                 }

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -33,6 +33,7 @@
             "elasticsearch": {
                 "title": "Search",
                 "disabled": "Search is not enabled",
+                "disabledTitle": "{engine} is not enabled",
                 "version": "Version",
                 "nodes": "Nodes",
                 "status": "Cluster Status",
@@ -75,7 +76,7 @@
                     }
                 },
                 "console": {
-                    "title": "Console",
+                    "title": "{engine} Console",
                     "send": "Send",
                     "output": "Output"
                 }


### PR DESCRIPTION
Follow-up to #421 — fixes the i18n gaps flagged by review.

## Problem
The disabled-state hero title and console panel title used hardcoded English string concatenation (`engineName + ' is not enabled'`), bypassing the i18n system and showing English-only text to non-English users.

## Fix
- Added `disabledTitle` and updated `console.title` snippet keys with `{engine}` placeholder in both `en-GB.json` and `de-DE.json`
- Template now uses parameterized `$t()` calls:
  - `$t('...disabledTitle', { engine: engineName })`
  - `$t('...console.title', { engine: engineName })`
- German locale now renders e.g. `OpenSearch ist nicht aktiviert` and `OpenSearch Konsole`