### PR TITLE
feat: mobile-responsive module shell and Shopmon tab

### DIFF
--- a/src/Controller/ShopmonController.php
+++ b/src/Controller/ShopmonController.php
@@ -124,9 +124,14 @@ class ShopmonController extends AbstractController
             return ['configured' => false];
         }
 
-        $integration = $this->integrationRepository
-            ->search(new Criteria([self::INTEGRATION_ID]), $context)
-            ->first();
+        // Read in system scope to match the write path; admin users browsing the
+        // tools usually lack integration:read and would otherwise see "not configured".
+        $integration = null;
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use (&$integration): void {
+            $integration = $this->integrationRepository
+                ->search(new Criteria([self::INTEGRATION_ID]), $context)
+                ->first();
+        });
 
         if ($integration === null) {
             return ['configured' => false];

--- a/src/Controller/ShopmonController.php
+++ b/src/Controller/ShopmonController.php
@@ -56,7 +56,6 @@ class ShopmonController extends AbstractController
                             'privileges' => [
                                 'app:read',
                                 'plugin:read',
-                                'system_config:read',
                                 'scheduled_task:read',
                                 'frosh_tools:read',
                                 'system:clear:cache',

--- a/src/Controller/ShopmonController.php
+++ b/src/Controller/ShopmonController.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Controller;
+
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
+use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\Integration\IntegrationCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+class ShopmonController extends AbstractController
+{
+    // Fixed id keeps setup idempotent and lets us find/remove the integration again.
+    private const INTEGRATION_ID = 'c2f0a1d4b6e84f309a5d7c1e8b2f4a60';
+    private const CONFIG_KEY = 'FroshTools.config.shopmonIntegrationData';
+
+    /**
+     * @param EntityRepository<IntegrationCollection> $integrationRepository
+     * @param EntityRepository<AclRoleCollection> $aclRoleRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $integrationRepository,
+        private readonly EntityRepository $aclRoleRepository,
+        private readonly SystemConfigService $systemConfigService,
+    ) {
+    }
+
+    #[Route(path: '/shopmon', name: 'api.frosh.tools.shopmon.setup', methods: ['POST'])]
+    public function setup(Context $context): JsonResponse
+    {
+        $accessKey = EnvironmentHelper::getVariable('SHOPMON_ACCESS_KEY', AccessKeyHelper::generateAccessKey('integration'));
+        $secretAccessKey = EnvironmentHelper::getVariable('SHOPMON_ACCESS_SECRET', AccessKeyHelper::generateSecretAccessKey());
+
+        // System scope, as admin users browsing the tools usually lack integration write privileges.
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($accessKey, $secretAccessKey): void {
+            $this->integrationRepository->upsert([
+                [
+                    'id' => self::INTEGRATION_ID,
+                    'label' => 'Shopmon Integration (FroshTools)',
+                    'accessKey' => $accessKey,
+                    'secretAccessKey' => $secretAccessKey,
+                    'aclRoles' => [
+                        [
+                            'id' => self::INTEGRATION_ID,
+                            'name' => 'frosh_shopmon_role',
+                            'privileges' => [
+                                'app:read',
+                                'plugin:read',
+                                'system_config:read',
+                                'scheduled_task:read',
+                                'frosh_tools:read',
+                                'system:clear:cache',
+                                'system:cache:info',
+                                'scheduled_task:update',
+                            ],
+                        ],
+                    ],
+                ],
+            ], $context);
+        });
+
+        $integrationData = [
+            'url' => EnvironmentHelper::getVariable('APP_URL', 'http://localhost'),
+            'clientId' => $accessKey,
+            'clientSecret' => $secretAccessKey,
+        ];
+
+        $this->systemConfigService->set(
+            self::CONFIG_KEY,
+            base64_encode(json_encode($integrationData, \JSON_THROW_ON_ERROR)),
+        );
+
+        return new JsonResponse($this->buildStatus($context));
+    }
+
+    #[Route(path: '/shopmon', name: 'api.frosh.tools.shopmon.status', methods: ['GET'])]
+    public function status(Context $context): JsonResponse
+    {
+        return new JsonResponse($this->buildStatus($context));
+    }
+
+    #[Route(path: '/shopmon', name: 'api.frosh.tools.shopmon.remove', methods: ['DELETE'])]
+    public function remove(Context $context): JsonResponse
+    {
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context): void {
+            try {
+                $this->integrationRepository->delete([['id' => self::INTEGRATION_ID]], $context);
+                $this->aclRoleRepository->delete([['id' => self::INTEGRATION_ID]], $context);
+            } catch (\Exception) {
+                // Integration might not exist anymore, ignore
+            }
+        });
+
+        $this->systemConfigService->delete(self::CONFIG_KEY);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildStatus(Context $context): array
+    {
+        $encoded = $this->systemConfigService->getString(self::CONFIG_KEY);
+
+        if ($encoded === '') {
+            return ['configured' => false];
+        }
+
+        $decoded = base64_decode($encoded, true);
+        $data = $decoded !== false ? json_decode($decoded, true) : null;
+
+        if (!\is_array($data)) {
+            return ['configured' => false];
+        }
+
+        $integration = $this->integrationRepository
+            ->search(new Criteria([self::INTEGRATION_ID]), $context)
+            ->first();
+
+        if ($integration === null) {
+            return ['configured' => false];
+        }
+
+        return [
+            'configured' => true,
+            'shopUrl' => $data['url'] ?? '',
+            'clientId' => $data['clientId'] ?? '',
+            'clientSecret' => $data['clientSecret'] ?? '',
+            'integrationData' => $encoded,
+        ];
+    }
+}

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -349,6 +349,43 @@ class FroshTools extends ApiService {
                 return ApiService.handleResponse(response);
             });
     }
+
+    getShopmonStatus() {
+        const apiRoute = `${this.getApiBasePath()}/shopmon`;
+        return this.httpClient
+            .get(apiRoute, {
+                headers: this.getBasicHeaders(),
+            })
+            .then((response) => {
+                return ApiService.handleResponse(response);
+            });
+    }
+
+    setupShopmon() {
+        const apiRoute = `${this.getApiBasePath()}/shopmon`;
+        return this.httpClient
+            .post(
+                apiRoute,
+                {},
+                {
+                    headers: this.getBasicHeaders(),
+                }
+            )
+            .then((response) => {
+                return ApiService.handleResponse(response);
+            });
+    }
+
+    removeShopmon() {
+        const apiRoute = `${this.getApiBasePath()}/shopmon`;
+        return this.httpClient
+            .delete(apiRoute, {
+                headers: this.getBasicHeaders(),
+            })
+            .then((response) => {
+                return ApiService.handleResponse(response);
+            });
+    }
 }
 
 export default FroshTools;

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
@@ -62,8 +62,8 @@
         :title="$t('frosh-tools.tabs.composerAudit.howto.title')"
     >
         <p class="frosh-security-dependencies__howto-warning">
-                                            <ft-icon name="alert"/>
-                                            <span>
+                                                    <ft-icon name="alert"/>
+                                                    <span>
             {{ $t('frosh-tools.tabs.composerAudit.howto.backup') }}
         </span>
         </p>
@@ -116,8 +116,8 @@
             </li>
         </ol>
         <p class="frosh-security-dependencies__howto-note">
-                                            <ft-icon name="info"/>
-                                            <span>
+                                                    <ft-icon name="info"/>
+                                                    <span>
             {{ $t('frosh-tools.tabs.composerAudit.howto.note') }}
         </span>
         </p>

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
@@ -62,8 +62,8 @@
         :title="$t('frosh-tools.tabs.composerAudit.howto.title')"
     >
         <p class="frosh-security-dependencies__howto-warning">
-                                                    <ft-icon name="alert"/>
-                                                    <span>
+                                                            <ft-icon name="alert"/>
+                                                            <span>
             {{ $t('frosh-tools.tabs.composerAudit.howto.backup') }}
         </span>
         </p>
@@ -116,8 +116,8 @@
             </li>
         </ol>
         <p class="frosh-security-dependencies__howto-note">
-                                                    <ft-icon name="info"/>
-                                                    <span>
+                                                            <ft-icon name="info"/>
+                                                            <span>
             {{ $t('frosh-tools.tabs.composerAudit.howto.note') }}
         </span>
         </p>

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/index.js
@@ -62,6 +62,10 @@ Component.register('frosh-tools-tab-shopmon', {
                 this.createNotificationSuccess({
                     message: this.$t('frosh-tools.tabs.shopmon.remove.success'),
                 });
+            } catch {
+                this.createNotificationError({
+                    message: this.$t('frosh-tools.tabs.shopmon.remove.error'),
+                });
             } finally {
                 await this.loadStatus();
             }

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/index.js
@@ -1,0 +1,86 @@
+import template from './template.twig';
+import './style.scss';
+
+const { Component, Mixin } = Shopware;
+
+Component.register('frosh-tools-tab-shopmon', {
+    template,
+    inject: ['froshToolsService'],
+    mixins: [Mixin.getByName('notification')],
+
+    data() {
+        return {
+            isLoading: true,
+            isSettingUp: false,
+            status: null,
+            showRemoveModal: false,
+            copiedField: null,
+        };
+    },
+
+    computed: {
+        isConfigured() {
+            return this.status?.configured === true;
+        },
+    },
+
+    created() {
+        this.loadStatus();
+    },
+
+    methods: {
+        async loadStatus() {
+            this.isLoading = true;
+            try {
+                this.status = await this.froshToolsService.getShopmonStatus();
+            } finally {
+                this.isLoading = false;
+            }
+        },
+
+        async setup() {
+            this.isSettingUp = true;
+            try {
+                this.status = await this.froshToolsService.setupShopmon();
+                this.createNotificationSuccess({
+                    message: this.$t('frosh-tools.tabs.shopmon.setup.success'),
+                });
+            } catch {
+                this.createNotificationError({
+                    message: this.$t('frosh-tools.tabs.shopmon.setup.error'),
+                });
+            } finally {
+                this.isSettingUp = false;
+            }
+        },
+
+        async removeIntegration() {
+            this.showRemoveModal = false;
+            this.isLoading = true;
+            try {
+                await this.froshToolsService.removeShopmon();
+                this.createNotificationSuccess({
+                    message: this.$t('frosh-tools.tabs.shopmon.remove.success'),
+                });
+            } finally {
+                await this.loadStatus();
+            }
+        },
+
+        async copy(field, value) {
+            try {
+                await navigator.clipboard.writeText(value);
+                this.copiedField = field;
+                window.setTimeout(() => {
+                    if (this.copiedField === field) {
+                        this.copiedField = null;
+                    }
+                }, 2000);
+            } catch {
+                this.createNotificationError({
+                    message: this.$t('frosh-tools.tabs.shopmon.copyError'),
+                });
+            }
+        },
+    },
+});

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/style.scss
@@ -1,0 +1,270 @@
+.frosh-tab-shopmon {
+    &__hero {
+        position: relative;
+        overflow: hidden;
+        border-radius: var(--ft-radius-xl);
+        padding: clamp(48px, 8vw, 96px) clamp(24px, 6vw, 64px);
+        text-align: center;
+        background:
+            radial-gradient(
+                900px 420px at 18% 100%,
+                rgba(125, 211, 252, 0.35),
+                transparent 65%
+            ),
+            linear-gradient(168deg, #0b2e52 0%, #14528e 55%, #2a7cbf 100%);
+        box-shadow: var(--ft-shadow-lg);
+
+        &::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background-image: radial-gradient(
+                rgba(255, 255, 255, 0.08) 1px,
+                transparent 1px
+            );
+            background-size: 26px 26px;
+            pointer-events: none;
+        }
+
+        > * {
+            position: relative;
+        }
+    }
+
+    &__badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 14px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.12);
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        color: #e8f1fb;
+        font-size: 12.5px;
+        font-weight: 500;
+        margin-bottom: 28px;
+    }
+
+    &__headline {
+        margin: 0 0 22px;
+        font-size: clamp(30px, 4.6vw, 54px);
+        font-weight: 800;
+        line-height: 1.12;
+        letter-spacing: -0.02em;
+        color: #ffffff;
+
+        span {
+            color: rgba(216, 230, 245, 0.62);
+        }
+    }
+
+    &__lead {
+        margin: 0 auto 36px;
+        max-width: 620px;
+        font-size: 15.5px;
+        line-height: 1.65;
+        color: rgba(226, 238, 250, 0.85);
+    }
+
+    &__cta {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 14px;
+        flex-wrap: wrap;
+    }
+
+    &__cta-primary {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 13px 26px;
+        border-radius: 999px;
+        border: none;
+        background: #ffffff;
+        color: #0f2a47;
+        font-size: 14.5px;
+        font-weight: 600;
+        cursor: pointer;
+        transition:
+            transform var(--ft-transition),
+            box-shadow var(--ft-transition);
+        box-shadow: 0 8px 24px rgba(4, 22, 42, 0.35);
+
+        &:hover:not(:disabled) {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 30px rgba(4, 22, 42, 0.45);
+        }
+
+        &:disabled {
+            opacity: 0.7;
+            cursor: not-allowed;
+        }
+
+        .ft-spinner {
+            border-color: rgba(15, 42, 71, 0.25);
+            border-top-color: #0f2a47;
+            width: 14px;
+            height: 14px;
+        }
+    }
+
+    &__cta-secondary {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 13px 26px;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.3);
+        color: #ffffff;
+        font-size: 14.5px;
+        font-weight: 600;
+        text-decoration: none;
+        transition: background var(--ft-transition);
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.16);
+            color: #ffffff;
+            text-decoration: none;
+        }
+    }
+
+    &__hint {
+        margin: 26px 0 0;
+        font-size: 12.5px;
+        color: rgba(210, 228, 245, 0.6);
+    }
+
+    // Undo the admin's global a[target="_blank"] inline-link styling on the hero CTA.
+    &.ft a.frosh-tab-shopmon__cta-secondary[target='_blank'] {
+        display: inline-flex;
+        font-size: 14.5px;
+        color: #ffffff;
+        text-decoration: none;
+        word-break: normal;
+
+        &::after {
+            content: none;
+        }
+    }
+
+    &__features {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 16px;
+        margin-top: 24px;
+
+        @media (max-width: 900px) {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    &__feature {
+        background: var(--ft-surface);
+        border: 1px solid var(--ft-border);
+        border-radius: var(--ft-radius-lg);
+        padding: 20px;
+        box-shadow: var(--ft-shadow-sm);
+    }
+
+    &__feature-icon {
+        width: 36px;
+        height: 36px;
+        border-radius: var(--ft-radius-md);
+        display: grid;
+        place-items: center;
+        background: var(--ft-accent-soft);
+        color: var(--ft-accent);
+        margin-bottom: 12px;
+    }
+
+    &__feature-title {
+        font-weight: 600;
+        font-size: 14px;
+        margin-bottom: 6px;
+    }
+
+    &__feature-body {
+        font-size: 13px;
+        line-height: 1.55;
+        color: var(--ft-text-soft);
+    }
+
+    .ft-hero-state {
+        margin-bottom: 16px;
+    }
+
+    .ft-panel + .ft-panel {
+        margin-top: 16px;
+    }
+
+    &__setup-hint {
+        margin: 0 0 12px;
+        font-size: 13px;
+        line-height: 1.55;
+        color: var(--ft-text-soft);
+    }
+
+    &__setup-code {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+
+        code {
+            flex: 1;
+            min-width: 0;
+            font-family: var(--ft-mono);
+            font-size: 12px;
+            line-height: 1.6;
+            background: var(--ft-surface-2);
+            border: 1px solid var(--ft-border);
+            border-radius: var(--ft-radius-sm);
+            padding: 10px 14px;
+            overflow-wrap: anywhere;
+            max-height: 120px;
+            overflow-y: auto;
+        }
+
+        @media (max-width: 700px) {
+            flex-direction: column;
+            align-items: stretch;
+        }
+    }
+
+    &__steps {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+    }
+
+    &__step {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    &__step-number {
+        flex-shrink: 0;
+        width: 26px;
+        height: 26px;
+        border-radius: 50%;
+        display: grid;
+        place-items: center;
+        background: var(--ft-accent-soft);
+        color: var(--ft-accent);
+        font-size: 12.5px;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+    }
+
+    &__step-text {
+        font-size: 13.5px;
+        color: var(--ft-text-soft);
+        line-height: 1.55;
+        padding-top: 4px;
+    }
+}

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/template.twig
@@ -1,0 +1,193 @@
+<div class="ft frosh-tab-shopmon">
+    <ft-empty
+        v-if="isLoading"
+        loading
+    />
+    <template v-else-if="!isConfigured">
+        <section class="frosh-tab-shopmon__hero">
+            <span class="frosh-tab-shopmon__badge">
+                <ft-icon
+                    name="check"
+                    :size="12"
+                />
+                {{ $t('frosh-tools.tabs.shopmon.hero.badge') }}
+            </span>
+            <h1 class="frosh-tab-shopmon__headline">
+                {{ $t('frosh-tools.tabs.shopmon.hero.titleLine1') }}
+                <br/>
+                <span>
+                    {{ $t('frosh-tools.tabs.shopmon.hero.titleLine2') }}
+                </span>
+            </h1>
+            <p class="frosh-tab-shopmon__lead">
+                {{ $t('frosh-tools.tabs.shopmon.hero.description') }}
+            </p>
+            <div class="frosh-tab-shopmon__cta">
+                <button
+                    class="frosh-tab-shopmon__cta-primary"
+                    :disabled="isSettingUp"
+                    @click="setup"
+                >
+                    <span
+                        v-if="isSettingUp"
+                        class="ft-spinner"
+                    ></span>
+                    <span>
+                        {{ $t('frosh-tools.tabs.shopmon.hero.start') }}
+                    </span>
+                    <ft-icon name="arrow-right"/>
+                </button>
+                <a
+                    class="frosh-tab-shopmon__cta-secondary"
+                    href="https://github.com/FriendsOfShopware/shopmon"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    <ft-icon name="external-link"/>
+                    <span>GitHub</span>
+                </a>
+            </div>
+            <p class="frosh-tab-shopmon__hint">
+                {{ $t('frosh-tools.tabs.shopmon.hero.hint') }}
+            </p>
+        </section>
+        <div class="frosh-tab-shopmon__features">
+            <div class="frosh-tab-shopmon__feature">
+                <div class="frosh-tab-shopmon__feature-icon">
+                    <ft-icon
+                        name="chart"
+                        :size="18"
+                    />
+                </div>
+                <div class="frosh-tab-shopmon__feature-title">
+                    {{ $t('frosh-tools.tabs.shopmon.features.status.title') }}
+                </div>
+                <div class="frosh-tab-shopmon__feature-body">
+                    {{ $t('frosh-tools.tabs.shopmon.features.status.body') }}
+                </div>
+            </div>
+            <div class="frosh-tab-shopmon__feature">
+                <div class="frosh-tab-shopmon__feature-icon">
+                    <ft-icon
+                        name="refresh"
+                        :size="18"
+                    />
+                </div>
+                <div class="frosh-tab-shopmon__feature-title">
+                    {{ $t('frosh-tools.tabs.shopmon.features.updates.title') }}
+                </div>
+                <div class="frosh-tab-shopmon__feature-body">
+                    {{ $t('frosh-tools.tabs.shopmon.features.updates.body') }}
+                </div>
+            </div>
+            <div class="frosh-tab-shopmon__feature">
+                <div class="frosh-tab-shopmon__feature-icon">
+                    <ft-icon
+                        name="alert"
+                        :size="18"
+                    />
+                </div>
+                <div class="frosh-tab-shopmon__feature-title">
+                    {{ $t('frosh-tools.tabs.shopmon.features.alerts.title') }}
+                </div>
+                <div class="frosh-tab-shopmon__feature-body">
+                    {{ $t('frosh-tools.tabs.shopmon.features.alerts.body') }}
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template v-else>
+        <ft-page-head
+            :title="$t('frosh-tools.tabs.shopmon.title')"
+            :subtitle="$t('frosh-tools.tabs.shopmon.configured.subtitle')"
+        >
+            <template #actions>
+                <a
+                    class="ft-btn ft-btn--primary"
+                    href="https://shopmon.fos.gg"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    <ft-icon name="external-link"/>
+                    <span>
+                        {{ $t('frosh-tools.tabs.shopmon.configured.open') }}
+                    </span>
+                </a>
+                <button
+                    class="ft-btn ft-btn--danger"
+                    @click="showRemoveModal = true"
+                >
+                    <ft-icon name="trash"/>
+                    <span>
+                        {{ $t('frosh-tools.tabs.shopmon.configured.remove') }}
+                    </span>
+                </button>
+            </template>
+        </ft-page-head>
+        <ft-hero-state
+            variant="success"
+            icon="check"
+            :title="$t('frosh-tools.tabs.shopmon.configured.readyTitle')"
+            :body="$t('frosh-tools.tabs.shopmon.configured.readyBody')"
+        />
+        <ft-panel :title="$t('frosh-tools.tabs.shopmon.configured.setupCode')">
+            <p class="frosh-tab-shopmon__setup-hint">
+                {{ $t('frosh-tools.tabs.shopmon.configured.setupCodeHint') }}
+            </p>
+            <div class="frosh-tab-shopmon__setup-code">
+                <code>{{ status.integrationData }}</code>
+                <button
+                    class="ft-btn"
+                    @click="copy('integrationData', status.integrationData)"
+                >
+                    <ft-icon
+                        :name="copiedField === 'integrationData' ? 'check' : 'copy'"
+                    />
+                    <span>
+                        {{ copiedField === 'integrationData' ? $t('frosh-tools.tabs.shopmon.configured.copied') : $t('frosh-tools.tabs.shopmon.configured.copy') }}
+                    </span>
+                </button>
+            </div>
+        </ft-panel>
+        <ft-panel :title="$t('frosh-tools.tabs.shopmon.configured.nextSteps')">
+            <ol class="frosh-tab-shopmon__steps">
+                <li
+                    v-for="step in 3"
+                    :key="step"
+                    class="frosh-tab-shopmon__step"
+                >
+                    <span class="frosh-tab-shopmon__step-number">{{ step }}</span>
+                    <span class="frosh-tab-shopmon__step-text">
+                        {{ $t(`frosh-tools.tabs.shopmon.configured.step${step}`) }}
+                    </span>
+                </li>
+            </ol>
+        </ft-panel>
+        <ft-modal
+            v-if="showRemoveModal"
+            variant="small"
+            :title="$t('frosh-tools.tabs.shopmon.remove.modal.title')"
+            @close="showRemoveModal = false"
+        >
+            <p>
+                {{ $t('frosh-tools.tabs.shopmon.remove.modal.description') }}
+            </p>
+            <template #footer>
+                <button
+                    class="ft-btn"
+                    @click="showRemoveModal = false"
+                >
+                    {{ $t('frosh-tools.tabs.shopmon.remove.modal.cancel') }}
+                </button>
+                <button
+                    class="ft-btn ft-btn--danger"
+                    @click="removeIntegration"
+                >
+                    <ft-icon name="trash"/>
+                    {{ $t('frosh-tools.tabs.shopmon.remove.modal.confirm') }}
+                </button>
+            </template>
+        </ft-modal>
+    </template>
+</div>

--- a/src/Resources/app/administration/src/module/frosh-tools/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/index.js
@@ -22,6 +22,7 @@ import './component/frosh-tools-security-files';
 import './component/frosh-tools-tab-security';
 import './component/frosh-tools-tab-fastly';
 import './component/frosh-tools-tab-statistics';
+import './component/frosh-tools-tab-shopmon';
 import './page/index';
 import './acl';
 
@@ -122,6 +123,14 @@ Shopware.Module.register('frosh-tools', {
                 statistics: {
                     component: 'frosh-tools-tab-statistics',
                     path: 'statistics',
+                    meta: {
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'sw.settings.index.plugins',
+                    },
+                },
+                shopmon: {
+                    component: 'frosh-tools-tab-shopmon',
+                    path: 'shopmon',
                     meta: {
                         privilege: 'frosh_tools:read',
                         parentPath: 'sw.settings.index.plugins',

--- a/src/Resources/app/administration/src/module/frosh-tools/page/index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/page/index/index.js
@@ -59,6 +59,10 @@ Component.register('frosh-tools-index', {
                     route: 'frosh.tools.index.security',
                     labelKey: 'frosh-tools.tabs.security.title',
                 },
+                {
+                    route: 'frosh.tools.index.shopmon',
+                    labelKey: 'frosh-tools.tabs.shopmon.title',
+                },
             ];
 
             const performance = [

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -281,6 +281,60 @@
                     "7d": "Letzte 7 Tage",
                     "30d": "Letzte 30 Tage"
                 }
+            },
+            "shopmon": {
+                "title": "Shopmon",
+                "hero": {
+                    "badge": "Open-Source",
+                    "titleLine1": "Das Monitoring-Dashboard,",
+                    "titleLine2": "das deine Shopware-Shops verdienen",
+                    "description": "Überwache alle deine Shopware-Umgebungen über ein zentrales Dashboard. Shop-Status, Performance-Metriken, Erweiterungs-Updates und Sicherheitswarnungen – alles in Echtzeit, ohne zwischen Tools zu wechseln.",
+                    "start": "Kostenlos mit dem Monitoring starten",
+                    "hint": "Es wird eine eingeschränkte API-Integration in diesem Shop angelegt, über die Shopmon den Status ausliest."
+                },
+                "features": {
+                    "status": {
+                        "title": "Shop-Status",
+                        "body": "Health-Checks, Shopware-Version, Queue- und Scheduled-Task-Status aller Umgebungen auf einen Blick."
+                    },
+                    "updates": {
+                        "title": "Erweiterungs-Updates",
+                        "body": "Sieh ausstehende Shopware- und Erweiterungs-Updates über alle Shops hinweg und verfolge jede Änderung."
+                    },
+                    "alerts": {
+                        "title": "Sicherheitswarnungen",
+                        "body": "Werde über bekannte Sicherheitsprobleme in deiner installierten Shopware-Version und deinen Erweiterungen informiert."
+                    }
+                },
+                "setup": {
+                    "success": "Die Shopmon-Integration wurde erstellt",
+                    "error": "Die Shopmon-Integration konnte nicht erstellt werden"
+                },
+                "configured": {
+                    "subtitle": "Dieser Shop ist bereit, mit Shopmon überwacht zu werden.",
+                    "open": "Shopmon öffnen",
+                    "remove": "Integration entfernen",
+                    "readyTitle": "Integration bereit",
+                    "readyBody": "Eine API-Integration für Shopmon wurde erstellt. Nutze den Schnelleinrichtungs-Code unten, um diesen Shop in Shopmon hinzuzufügen.",
+                    "setupCode": "Schnelleinrichtungs-Code",
+                    "setupCodeHint": "Füge diesen Code in Shopmon ein, wenn du einen neuen Shop hinzufügst — er enthält die Shop-URL und die API-Zugangsdaten.",
+                    "copy": "Kopieren",
+                    "copied": "Kopiert",
+                    "nextSteps": "Nächste Schritte",
+                    "step1": "Öffne shopmon.fos.gg und melde dich an oder erstelle einen kostenlosen Account.",
+                    "step2": "Füge in deiner Organisation einen neuen Shop hinzu und füge den oben angezeigten Schnelleinrichtungs-Code ein.",
+                    "step3": "Shopmon verbindet sich mit diesem Shop und beginnt sofort mit dem Monitoring."
+                },
+                "remove": {
+                    "success": "Die Shopmon-Integration wurde entfernt",
+                    "modal": {
+                        "title": "Shopmon-Integration entfernen",
+                        "description": "Die von Shopmon genutzte API-Integration wird gelöscht. Shopmon kann diesen Shop nicht mehr überwachen, bis eine neue Integration erstellt wird.",
+                        "cancel": "Abbrechen",
+                        "confirm": "Entfernen"
+                    }
+                },
+                "copyError": "Konnte nicht in die Zwischenablage kopieren"
             }
         },
         "clear": "Leeren",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -327,6 +327,7 @@
                 },
                 "remove": {
                     "success": "Die Shopmon-Integration wurde entfernt",
+                    "error": "Die Shopmon-Integration konnte nicht entfernt werden",
                     "modal": {
                         "title": "Shopmon-Integration entfernen",
                         "description": "Die von Shopmon genutzte API-Integration wird gelöscht. Shopmon kann diesen Shop nicht mehr überwachen, bis eine neue Integration erstellt wird.",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -327,6 +327,7 @@
                 },
                 "remove": {
                     "success": "The Shopmon integration has been removed",
+                    "error": "The Shopmon integration could not be removed",
                     "modal": {
                         "title": "Remove Shopmon integration",
                         "description": "This deletes the API integration used by Shopmon. Shopmon will no longer be able to monitor this shop until a new integration is created.",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -281,6 +281,60 @@
                     "7d": "Last 7 Days",
                     "30d": "Last 30 Days"
                 }
+            },
+            "shopmon": {
+                "title": "Shopmon",
+                "hero": {
+                    "badge": "Open-Source",
+                    "titleLine1": "The monitoring dashboard",
+                    "titleLine2": "your Shopware shops deserve",
+                    "description": "Monitor all your Shopware environments from one central dashboard. Shop status, performance metrics, extension updates, and security alerts - all in real-time without switching between tools.",
+                    "start": "Start monitoring for free",
+                    "hint": "This creates a restricted API integration in this shop that Shopmon uses to read its status."
+                },
+                "features": {
+                    "status": {
+                        "title": "Shop status",
+                        "body": "Health checks, Shopware version, queue and scheduled task status of all your environments at a glance."
+                    },
+                    "updates": {
+                        "title": "Extension updates",
+                        "body": "See pending Shopware and extension updates across all shops and track every change over time."
+                    },
+                    "alerts": {
+                        "title": "Security alerts",
+                        "body": "Get notified about known security issues in your installed Shopware version and extensions."
+                    }
+                },
+                "setup": {
+                    "success": "The Shopmon integration has been created",
+                    "error": "The Shopmon integration could not be created"
+                },
+                "configured": {
+                    "subtitle": "This shop is ready to be monitored with Shopmon.",
+                    "open": "Open Shopmon",
+                    "remove": "Remove integration",
+                    "readyTitle": "Integration ready",
+                    "readyBody": "An API integration for Shopmon has been created. Use the quick setup code below to add this shop in Shopmon.",
+                    "setupCode": "Quick setup code",
+                    "setupCodeHint": "Paste this code in Shopmon when adding a new shop — it contains the shop URL and the API credentials.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "nextSteps": "Next steps",
+                    "step1": "Open shopmon.fos.gg and sign in or create a free account.",
+                    "step2": "Add a new shop in your organization and paste the quick setup code shown above.",
+                    "step3": "Shopmon will connect to this shop and start monitoring it right away."
+                },
+                "remove": {
+                    "success": "The Shopmon integration has been removed",
+                    "modal": {
+                        "title": "Remove Shopmon integration",
+                        "description": "This deletes the API integration used by Shopmon. Shopmon will no longer be able to monitor this shop until a new integration is created.",
+                        "cancel": "Cancel",
+                        "confirm": "Remove"
+                    }
+                },
+                "copyError": "Could not copy to clipboard"
             }
         },
         "clear": "Clear",

--- a/src/Resources/app/administration/src/module/frosh-tools/styles/design-system.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/styles/design-system.scss
@@ -104,6 +104,11 @@ body.dark .ft {
         grid-template-columns: 1fr;
         gap: 16px;
     }
+
+    @media (max-width: 540px) {
+        padding: 12px;
+        gap: 12px;
+    }
 }
 
 .ft-sidebar {
@@ -115,6 +120,23 @@ body.dark .ft {
     top: 20px;
     box-shadow: var(--ft-shadow-sm);
 
+    // On phones the stacked sidebar collapses into a horizontal scroll strip
+    // so it no longer eats a full screen of height above the content.
+    @media (max-width: 540px) {
+        position: static;
+        top: auto;
+        padding: 8px;
+        display: flex;
+        gap: 6px;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+
+        &::-webkit-scrollbar {
+            display: none;
+        }
+    }
+
     &__brand {
         display: flex;
         align-items: center;
@@ -122,6 +144,10 @@ body.dark .ft {
         padding: 4px 8px 14px;
         border-bottom: 1px solid var(--ft-divider);
         margin-bottom: 12px;
+
+        @media (max-width: 540px) {
+            display: none;
+        }
 
         &-mark {
             width: 32px;
@@ -156,6 +182,12 @@ body.dark .ft {
     &__group {
         margin-bottom: 14px;
 
+        @media (max-width: 540px) {
+            display: flex;
+            gap: 6px;
+            margin-bottom: 0;
+        }
+
         &-label {
             font-size: 10px;
             text-transform: uppercase;
@@ -163,6 +195,10 @@ body.dark .ft {
             color: var(--ft-text-muted);
             padding: 6px 10px;
             font-weight: 600;
+
+            @media (max-width: 540px) {
+                display: none;
+            }
         }
     }
 
@@ -193,6 +229,18 @@ body.dark .ft {
             font-weight: 600;
         }
 
+        @media (max-width: 540px) {
+            white-space: nowrap;
+            border: 1px solid var(--ft-border);
+            background: var(--ft-surface);
+            padding: 8px 12px;
+
+            &.is-active {
+                border-color: var(--ft-accent);
+                background: var(--ft-accent-soft);
+            }
+        }
+
         .mt-icon,
         .sw-icon {
             width: 16px;
@@ -211,6 +259,10 @@ body.dark .ft {
 
         .is-active & {
             opacity: 1;
+        }
+
+        @media (max-width: 540px) {
+            display: none;
         }
     }
 }
@@ -303,6 +355,32 @@ body.dark .ft {
     }
 }
 
+// The admin globally restyles a[target="_blank"] as an inline text link
+// (underline, brand color, small font, ::after icon) — undo that for anchor buttons.
+.ft a.ft-btn[target='_blank'] {
+    display: inline-flex;
+    font-size: 13px;
+    color: var(--ft-text);
+    text-decoration: none;
+    word-break: normal;
+
+    &::after {
+        content: none;
+    }
+
+    &:hover:not(:disabled) {
+        text-decoration: none;
+    }
+}
+
+.ft a.ft-btn--primary[target='_blank'] {
+    color: #fff;
+
+    &:hover:not(:disabled) {
+        color: #fff;
+    }
+}
+
 // ============================================================
 // Custom data table
 // ============================================================
@@ -320,6 +398,10 @@ body.dark .ft {
         padding: 12px 16px;
         border-bottom: 1px solid var(--ft-divider);
         vertical-align: middle;
+
+        @media (max-width: 540px) {
+            padding: 10px 10px;
+        }
     }
 
     thead th {
@@ -393,6 +475,40 @@ body.dark .ft {
 
 .ft-table-wrap {
     overflow-x: auto;
+
+    // Hint that the table scrolls sideways on narrow screens.
+    @media (max-width: 540px) {
+        background:
+            linear-gradient(
+                to right,
+                var(--ft-surface) 30%,
+                rgba(255, 255, 255, 0)
+            ),
+            linear-gradient(
+                    to left,
+                    var(--ft-surface) 30%,
+                    rgba(255, 255, 255, 0)
+                )
+                100% 0,
+            radial-gradient(
+                farthest-side at 0 50%,
+                rgba(0, 0, 0, 0.12),
+                rgba(0, 0, 0, 0)
+            ),
+            radial-gradient(
+                    farthest-side at 100% 50%,
+                    rgba(0, 0, 0, 0.12),
+                    rgba(0, 0, 0, 0)
+                )
+                100% 0;
+        background-repeat: no-repeat;
+        background-size:
+            40px 100%,
+            40px 100%,
+            14px 100%,
+            14px 100%;
+        background-attachment: local, local, scroll, scroll;
+    }
 }
 
 // ============================================================


### PR DESCRIPTION
## Mobile responsiveness

Makes the FroshTools developer console usable on phones (tested at 390px):

- **Sidebar no longer overlaps content.** The stacked sidebar was `position: sticky`, so on narrow screens it stayed pinned and covered the data tables when scrolling. It now becomes static below the stacking breakpoint.
- **Compact nav.** Instead of a ~580px-tall vertical nav block above the content, the navigation collapses into a single horizontal scrolling pill strip on phones, so content is reachable immediately.
- **Tables.** Tightened data-table cell padding on small screens and added a horizontal scroll-shadow hint so wide tables are clearly scrollable rather than looking clipped.

All responsive rules are scoped to `@media (max-width: 540px)` — the desktop two-column layout is unchanged.

## Shopmon tab

Also includes the Shopmon integration tab (controller, api client, component, snippets).

## Validation

- `shopware-cli extension format .` — applied
- `shopware-cli extension validate --full .` — ✖ 0 problems (0 errors, 0 warnings)