### PR TITLE
Add support for Sentry traceable cache adapters in CacheAdapter

### DIFF
--- a/src/Components/CacheAdapter.php
+++ b/src/Components/CacheAdapter.php
@@ -17,6 +17,12 @@ use Symfony\Component\Cache\Adapter\TraceableAdapter;
 
 class CacheAdapter
 {
+    public const TYPE_REDIS = 'Redis';
+    public const TYPE_REDIS_TAG_AWARE = 'Redis (TagAware)';
+    public const TYPE_FILESYSTEM = 'Filesystem';
+    public const TYPE_ARRAY = 'Array';
+    public const TYPE_PHP_FILES = 'PHP files';
+    public const TYPE_APCU = 'APCu';
     /**
      * Sentry's cache tracing (sentry.tracing.cache.enabled) decorates the pools.
      * These are stable class_alias names registered by the bundle; the concrete
@@ -26,13 +32,6 @@ class CacheAdapter
         'Sentry\\SentryBundle\\Tracing\\Cache\\TraceableTagAwareCacheAdapter',
         'Sentry\\SentryBundle\\Tracing\\Cache\\TraceableCacheAdapter',
     ];
-
-    public const TYPE_REDIS = 'Redis';
-    public const TYPE_REDIS_TAG_AWARE = 'Redis (TagAware)';
-    public const TYPE_FILESYSTEM = 'Filesystem';
-    public const TYPE_ARRAY = 'Array';
-    public const TYPE_PHP_FILES = 'PHP files';
-    public const TYPE_APCU = 'APCu';
 
     private readonly AdapterInterface $adapter;
 
@@ -155,6 +154,7 @@ class CacheAdapter
         }
 
         foreach (self::SENTRY_TRACEABLE_CACHE_ADAPTERS as $sentryAdapterClass) {
+            // @phpstan-ignore-next-line booleanAnd.alwaysFalse, function.impossibleType, instanceof.alwaysFalse
             if (class_exists($sentryAdapterClass) && $adapter instanceof $sentryAdapterClass) {
                 // @phpstan-ignore-next-line property.notFound
                 $func = \Closure::bind(fn () => $adapter->decoratedAdapter, $adapter, $adapter::class);

--- a/src/Components/CacheAdapter.php
+++ b/src/Components/CacheAdapter.php
@@ -17,6 +17,16 @@ use Symfony\Component\Cache\Adapter\TraceableAdapter;
 
 class CacheAdapter
 {
+    /**
+     * Sentry's cache tracing (sentry.tracing.cache.enabled) decorates the pools.
+     * These are stable class_alias names registered by the bundle; the concrete
+     * version-specific class stores the real adapter in a private $decoratedAdapter.
+     */
+    private const SENTRY_TRACEABLE_CACHE_ADAPTERS = [
+        'Sentry\\SentryBundle\\Tracing\\Cache\\TraceableTagAwareCacheAdapter',
+        'Sentry\\SentryBundle\\Tracing\\Cache\\TraceableCacheAdapter',
+    ];
+
     public const TYPE_REDIS = 'Redis';
     public const TYPE_REDIS_TAG_AWARE = 'Redis (TagAware)';
     public const TYPE_FILESYSTEM = 'Filesystem';
@@ -142,6 +152,15 @@ class CacheAdapter
             $func = \Closure::bind(fn () => $adapter->decorated, $adapter, $adapter::class);
 
             return $this->getCacheAdapter($func());
+        }
+
+        foreach (self::SENTRY_TRACEABLE_CACHE_ADAPTERS as $sentryAdapterClass) {
+            if (class_exists($sentryAdapterClass) && $adapter instanceof $sentryAdapterClass) {
+                // @phpstan-ignore-next-line property.notFound
+                $func = \Closure::bind(fn () => $adapter->decoratedAdapter, $adapter, $adapter::class);
+
+                return $this->getCacheAdapter($func());
+            }
         }
 
         if ($adapter instanceof TagAwareAdapter || $adapter instanceof TraceableAdapter) {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-dependencies/template.twig
@@ -64,8 +64,8 @@
         <p class="frosh-security-dependencies__howto-warning">
                                             <ft-icon name="alert"/>
                                             <span>
-            {{ $t('frosh-tools.tabs.composerAudit.howto.backup') }}
-        </span>
+    {{ $t('frosh-tools.tabs.composerAudit.howto.backup') }}
+</span>
         </p>
         <ol class="frosh-security-dependencies__howto">
             <li class="frosh-security-dependencies__howto-step">
@@ -118,8 +118,8 @@
         <p class="frosh-security-dependencies__howto-note">
                                             <ft-icon name="info"/>
                                             <span>
-            {{ $t('frosh-tools.tabs.composerAudit.howto.note') }}
-        </span>
+    {{ $t('frosh-tools.tabs.composerAudit.howto.note') }}
+</span>
         </p>
     </ft-panel>
     <ft-panel


### PR DESCRIPTION
Problem

When Sentry's cache tracing is enabled (sentry.tracing.cache.enabled: true), the Sentry bundle wraps every cache pool in a TraceableTagAwareCacheAdapter / TraceableCacheAdapter (the real adapter is hidden in a private $decoratedAdapter).
CacheAdapter::getCacheAdapter() doesn't unwrap this decorator, so $this->adapter ends up being the Sentry wrapper instead of the underlying RedisTagAwareAdapter. As a result, Redis detection fails and the cache tools break with errors like "This cache adapter is not a Redis adapter" / "...Only RedisTagAwareAdapter is supported."

Fix
Extend the existing recursive unwrapping in getCacheAdapter() to also unwrap the Sentry traceable adapters (matched via their stable class_alias names, guarded by class_exists()). Once unwrapped, the real adapter is detected and all existing logic works unchanged.

Notes
• Safe when Sentry is not installed — the class_exists() guard makes it a no-op, no hard dependency added.
• Covers all Symfony versions, since the bundle aliases the version-specific classes to the two stable names.