### PR TITLE
fix: total cache in opcache statistics

### DIFF
--- a/src/Components/CacheStatisticsService.php
+++ b/src/Components/CacheStatisticsService.php
@@ -35,6 +35,11 @@ class CacheStatisticsService
         $misses = (int) ($stats['misses'] ?? 0);
         $total = $hits + $misses;
 
+        $usedMemory = (int) ($memory['used_memory'] ?? 0);
+        $freeMemory = (int) ($memory['free_memory'] ?? 0);
+        $wastedMemory = (int) ($memory['wasted_memory'] ?? 0);
+        $totalMemory = $usedMemory + $wastedMemory + $freeMemory;
+
         $maxScripts = 0;
         if ($config !== false) {
             $maxScripts = (int) $config['directives']['opcache.max_accelerated_files'];
@@ -50,9 +55,10 @@ class CacheStatisticsService
             'hitRate' => $total > 0 ? round($hits / $total * 100, 2) : 0.0,
             'hits' => $hits,
             'misses' => $misses,
-            'usedMemory' => (int) ($memory['used_memory'] ?? 0),
-            'freeMemory' => (int) ($memory['free_memory'] ?? 0),
-            'wastedMemory' => (int) ($memory['wasted_memory'] ?? 0),
+            'usedMemory' => $usedMemory,
+            'freeMemory' => $freeMemory,
+            'wastedMemory' => $wastedMemory,
+            'totalMemory' => $totalMemory,
             'wastedPercentage' => round((float) ($memory['current_wasted_percentage'] ?? 0), 2),
             'cachedScripts' => (int) ($stats['num_cached_scripts'] ?? 0),
             'maxCachedScripts' => $maxScripts,

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-statistics/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-statistics/template.twig
@@ -53,14 +53,14 @@
                     {{ $t('frosh-tools.tabs.statistics.totalMemory') }}
                 </div>
                 <div class="frosh-stat__value">
-                    {{ formatSize(cacheStats.opcache.usedMemory) }}
+                    {{ formatSize(cacheStats.opcache.usedMemory + cacheStats.opcache.wastedMemory) }}
                     /
                     {{ formatSize(cacheStats.opcache.totalMemory) }}
                 </div>
                 <div class="frosh-meter">
                     <div
-                        :class="['frosh-meter__fill', 'frosh-meter__fill--' + fillVariant(ratioPercent(cacheStats.opcache.usedMemory, cacheStats.opcache.totalMemory))]"
-                        :style="{ width: ratioPercent(cacheStats.opcache.usedMemory, cacheStats.opcache.totalMemory) + '%' }"
+                        :class="['frosh-meter__fill', 'frosh-meter__fill--' + fillVariant(ratioPercent(cacheStats.opcache.usedMemory + cacheStats.opcache.wastedMemory, cacheStats.opcache.totalMemory))]"
+                        :style="{ width: ratioPercent(cacheStats.opcache.usedMemory + cacheStats.opcache.wastedMemory, cacheStats.opcache.totalMemory) + '%' }"
                     ></div>
                 </div>
             </div>

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-statistics/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-statistics/template.twig
@@ -55,12 +55,12 @@
                 <div class="frosh-stat__value">
                     {{ formatSize(cacheStats.opcache.usedMemory) }}
                     /
-                    {{ formatSize(cacheStats.opcache.usedMemory + cacheStats.opcache.freeMemory) }}
+                    {{ formatSize(cacheStats.opcache.totalMemory) }}
                 </div>
                 <div class="frosh-meter">
                     <div
-                        :class="['frosh-meter__fill', 'frosh-meter__fill--' + fillVariant(ratioPercent(cacheStats.opcache.usedMemory, cacheStats.opcache.usedMemory + cacheStats.opcache.freeMemory))]"
-                        :style="{ width: ratioPercent(cacheStats.opcache.usedMemory, cacheStats.opcache.usedMemory + cacheStats.opcache.freeMemory) + '%' }"
+                        :class="['frosh-meter__fill', 'frosh-meter__fill--' + fillVariant(ratioPercent(cacheStats.opcache.usedMemory, cacheStats.opcache.totalMemory))]"
+                        :style="{ width: ratioPercent(cacheStats.opcache.usedMemory, cacheStats.opcache.totalMemory) + '%' }"
                     ></div>
                 </div>
             </div>


### PR DESCRIPTION
At the moment, total cache calculation is missing `wastedCache` which leads to a wrong total cache value.