### PR TITLE
fix: add handling of deprecated cache compression options

### DIFF
--- a/src/Components/Health/Checker/PerformanceChecker/CompressionMethodChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/CompressionMethodChecker.php
@@ -11,18 +11,41 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class CompressionMethodChecker implements PerformanceCheckerInterface, CheckerInterface
 {
+    public readonly bool $cacheCompressionEnabled;
+
+    public readonly string $cacheCompressionMethod;
+
     public function __construct(
         #[Autowire(param: 'kernel.shopware_version')]
         public readonly string $shopwareVersion,
         #[Autowire(param: 'shopware.cache.cache_compression')]
-        public readonly bool $cacheCompressionEnabled,
+        public readonly ?bool $deprecatedCacheCompressionEnabled,
         #[Autowire(param: 'shopware.cache.cache_compression_method')]
-        public readonly string $cacheCompressionMethod,
+        public readonly ?string $deprecatedCacheCompressionMethod,
+        #[Autowire(param: 'shopware.cache.compress')]
+        ?bool $cacheCompressionEnabled,
+        #[Autowire(param: 'shopware.cache.compression_method')]
+        ?string $cacheCompressionMethod,
         #[Autowire(param: 'shopware.cart.compress')]
         public readonly bool $cartCompressionEnabled,
         #[Autowire(param: 'shopware.cart.compression_method')]
         public readonly string $cartCompressionMethod,
     ) {
+        if ($cacheCompressionEnabled === null) {
+            \assert($this->deprecatedCacheCompressionEnabled !== null);
+
+            $this->cacheCompressionEnabled = $this->deprecatedCacheCompressionEnabled;
+        } else {
+            $this->cacheCompressionEnabled = $cacheCompressionEnabled;
+        }
+
+        if ($cacheCompressionMethod === null) {
+            \assert($this->deprecatedCacheCompressionMethod !== null);
+
+            $this->cacheCompressionMethod = $this->deprecatedCacheCompressionMethod;
+        } else {
+            $this->cacheCompressionMethod = $cacheCompressionMethod;
+        }
     }
 
     public function collect(HealthCollection $collection): void


### PR DESCRIPTION
With the new cache compression options coming with Showare 6.7.12.0, the "Performance recommendations" section is not loading because `/performance/status` API is failing with error 500.

- fixes #434