### PR TITLE
test: add kernel-based integration tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,16 +21,59 @@ on:
 
 jobs:
   phpunit:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         shopware-version:
           - '6.6.x'
           - 'trunk'
-    uses: shopware/github-actions/.github/workflows/phpunit.yml@main
-    with:
-      extensionName: ${{ github.event.repository.name }}
-      shopwareVersion: ${{ matrix.shopware-version }}
-      uploadCoverage: true
-    secrets:
-      codecovToken: ${{ secrets.CODECOV_TOKEN }}
+        mysql-version:
+          - 'builtin'
+          - 'mariadb:11.8'
+    steps:
+      - name: Setup Extension
+        uses: shopware/github-actions/setup-extension@main
+        with:
+          extensionName: ${{ github.event.repository.name }}
+          shopwareVersion: ${{ matrix.shopware-version }}
+          mysqlVersion: ${{ matrix.mysql-version }}
+
+      - name: Run PHPUnit
+        uses: shopware/github-actions/phpunit@main
+        with:
+          extensionName: ${{ github.event.repository.name }}
+          uploadCoverage: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  opensearch:
+    runs-on: ubuntu-latest
+    services:
+      opensearch:
+        image: opensearchproject/opensearch:2
+        env:
+          discovery.type: single-node
+          DISABLE_SECURITY_PLUGIN: 'true'
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myWeakPassword123!'
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      OPENSEARCH_URL: http://localhost:9200
+      SHOPWARE_ES_ENABLED: '1'
+      SHOPWARE_ES_INDEXING_ENABLED: '1'
+    steps:
+      - name: Setup Extension
+        uses: shopware/github-actions/setup-extension@main
+        with:
+          extensionName: ${{ github.event.repository.name }}
+
+      - name: Run PHPUnit
+        uses: shopware/github-actions/phpunit@main
+        with:
+          extensionName: ${{ github.event.repository.name }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -38,6 +38,13 @@ jobs:
           extensionName: ${{ github.event.repository.name }}
           shopwareVersion: ${{ matrix.shopware-version }}
           mysqlVersion: ${{ matrix.mysql-version }}
+          extraRepositories: |-
+            {
+              "local-plugins": {
+                "type": "path",
+                "url": "custom/plugins/*"
+              }
+            }
 
       - name: Run PHPUnit
         uses: shopware/github-actions/phpunit@main
@@ -72,6 +79,13 @@ jobs:
         uses: shopware/github-actions/setup-extension@main
         with:
           extensionName: ${{ github.event.repository.name }}
+          extraRepositories: |-
+            {
+              "local-plugins": {
+                "type": "path",
+                "url": "custom/plugins/*"
+              }
+            }
 
       - name: Run PHPUnit
         uses: shopware/github-actions/phpunit@main

--- a/tests/Components/DatabaseStatisticsServiceTest.php
+++ b/tests/Components/DatabaseStatisticsServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components;
+
+use Frosh\Tools\Components\DatabaseStatisticsService;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(DatabaseStatisticsService::class)]
+class DatabaseStatisticsServiceTest extends IntegrationTestCase
+{
+    private DatabaseStatisticsService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = static::getContainer()->get(DatabaseStatisticsService::class);
+    }
+
+    public function testGetServerInfo(): void
+    {
+        $info = $this->service->getServerInfo();
+
+        static::assertArrayHasKey('version', $info);
+        static::assertNotSame('', $info['version']);
+        static::assertGreaterThanOrEqual(0, $info['uptime']);
+        static::assertGreaterThanOrEqual(0, $info['threads']);
+        static::assertGreaterThanOrEqual(0, $info['questions']);
+        static::assertGreaterThanOrEqual(0, $info['slowQueries']);
+        static::assertIsFloat($info['queriesPerSecond']);
+    }
+
+    public function testGetTableStatistics(): void
+    {
+        $tables = $this->service->getTableStatistics();
+
+        static::assertNotEmpty($tables);
+
+        $names = array_column($tables, 'name');
+        static::assertContains('product', $names);
+
+        foreach ($tables as $table) {
+            static::assertArrayHasKey('name', $table);
+            static::assertArrayHasKey('engine', $table);
+            static::assertArrayHasKey('rows', $table);
+            static::assertArrayHasKey('dataSize', $table);
+            static::assertArrayHasKey('indexSize', $table);
+            static::assertArrayHasKey('totalSize', $table);
+            static::assertSame($table['dataSize'] + $table['indexSize'], $table['totalSize']);
+        }
+
+        $sizes = array_column($tables, 'totalSize');
+        $sorted = $sizes;
+        rsort($sorted);
+        static::assertSame($sorted, $sizes, 'Tables should be sorted by total size descending');
+    }
+
+    public function testGetGlobalStatus(): void
+    {
+        $status = $this->service->getGlobalStatus();
+
+        foreach (['bufferPoolSize', 'bufferPoolUsed', 'bufferPoolHitRate', 'threadsConnected', 'threadsRunning', 'slowQueries', 'tmpDiskTables', 'tmpTables'] as $key) {
+            static::assertArrayHasKey($key, $status);
+        }
+
+        static::assertGreaterThan(0, $status['bufferPoolSize']);
+        static::assertGreaterThanOrEqual(0, $status['bufferPoolHitRate']);
+        static::assertLessThanOrEqual(100, $status['bufferPoolHitRate']);
+    }
+}

--- a/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\Health\Checker\HealthChecker;
+
+use Doctrine\DBAL\Connection;
+use Frosh\Tools\Components\Health\Checker\HealthChecker\QueueChecker;
+use Frosh\Tools\Components\Health\HealthCollection;
+use Frosh\Tools\Components\Health\SettingsResult;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(QueueChecker::class)]
+class QueueCheckerTest extends IntegrationTestCase
+{
+    private QueueChecker $checker;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->checker = static::getContainer()->get(QueueChecker::class);
+        $this->connection = static::getContainer()->get(Connection::class);
+
+        $this->connection->executeStatement('DELETE FROM messenger_messages');
+    }
+
+    public function testEmptyQueueResultsInInfoState(): void
+    {
+        $result = $this->collectQueueResult();
+
+        static::assertSame(SettingsResult::INFO, $result->state);
+    }
+
+    public function testOldMessageResultsInWarningState(): void
+    {
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 2 HOUR');
+
+        $result = $this->collectQueueResult();
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+    }
+
+    public function testRecentMessageWithinGracePeriodResultsInOkState(): void
+    {
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 1 MINUTE');
+
+        $result = $this->collectQueueResult();
+
+        static::assertSame(SettingsResult::GREEN, $result->state);
+    }
+
+    private function insertMessage(string $availableAt): void
+    {
+        $this->connection->executeStatement(\sprintf(
+            "INSERT INTO messenger_messages (body, headers, queue_name, created_at, available_at) VALUES ('a:0:{}', '[]', 'default', UTC_TIMESTAMP(), %s)",
+            $availableAt,
+        ));
+    }
+
+    private function collectQueueResult(): SettingsResult
+    {
+        $collection = new HealthCollection();
+        $this->checker->collect($collection);
+
+        foreach ($collection->getElements() as $element) {
+            if ($element->id === 'queue') {
+                return $element;
+            }
+        }
+
+        static::fail('HealthCollection does not contain a result with id "queue"');
+    }
+}

--- a/tests/Components/Health/Checker/HealthChecker/TaskCheckerTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/TaskCheckerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\Health\Checker\HealthChecker;
+
+use Doctrine\DBAL\Connection;
+use Frosh\Tools\Components\Health\Checker\HealthChecker\TaskChecker;
+use Frosh\Tools\Components\Health\HealthCollection;
+use Frosh\Tools\Components\Health\SettingsResult;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TaskChecker::class)]
+class TaskCheckerTest extends IntegrationTestCase
+{
+    private TaskChecker $checker;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->checker = static::getContainer()->get(TaskChecker::class);
+        $this->connection = static::getContainer()->get(Connection::class);
+    }
+
+    public function testCollectReportsOkWhenNoTaskIsOverdue(): void
+    {
+        $this->connection->executeStatement('UPDATE scheduled_task SET next_execution_time = DATE_ADD(NOW(), INTERVAL 1 DAY)');
+
+        $result = $this->collectScheduledTaskResult();
+
+        static::assertSame(SettingsResult::GREEN, $result->state);
+    }
+
+    public function testCollectReportsWarningWhenTaskIsOverdue(): void
+    {
+        $this->connection->executeStatement('UPDATE scheduled_task SET next_execution_time = DATE_ADD(NOW(), INTERVAL 1 DAY)');
+
+        // The checker ignores inactive and skipped tasks, so only qualifying rows are made overdue
+        $this->connection->executeStatement(
+            "UPDATE scheduled_task SET next_execution_time = DATE_SUB(NOW(), INTERVAL 2 HOUR) WHERE status NOT IN ('inactive', 'skipped')"
+        );
+
+        $result = $this->collectScheduledTaskResult();
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+    }
+
+    private function collectScheduledTaskResult(): SettingsResult
+    {
+        $collection = new HealthCollection();
+        $this->checker->collect($collection);
+
+        foreach ($collection->getElements() as $element) {
+            if ($element->id === 'scheduled_task') {
+                return $element;
+            }
+        }
+
+        static::fail('TaskChecker did not add a result with id "scheduled_task" to the collection');
+    }
+}

--- a/tests/Controller/CacheControllerTest.php
+++ b/tests/Controller/CacheControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Controller\CacheController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(CacheController::class)]
+class CacheControllerTest extends IntegrationTestCase
+{
+    private CacheController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = static::getContainer()->get(CacheController::class);
+    }
+
+    public function testCacheStatisticsReturnsListWithKnownAdapters(): void
+    {
+        $response = $this->controller->cacheStatistics();
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $entries = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($entries);
+        static::assertNotEmpty($entries);
+
+        $names = array_column($entries, 'name');
+        static::assertContains('cache.app', $names);
+
+        foreach ($entries as $entry) {
+            static::assertIsArray($entry);
+            static::assertArrayHasKey('name', $entry);
+            static::assertArrayHasKey('active', $entry);
+            static::assertArrayHasKey('size', $entry);
+            static::assertArrayHasKey('freeSpace', $entry);
+            static::assertArrayHasKey('type', $entry);
+        }
+    }
+
+    public function testClearCacheWithUnknownFolderReturnsNoContent(): void
+    {
+        $folder = 'definitely-not-existing-frosh';
+        $cacheDir = (string) static::getContainer()->getParameter('kernel.cache_dir');
+        $folderPath = \dirname($cacheDir) . '/' . $folder;
+
+        try {
+            $response = $this->controller->clearCache($folder);
+
+            // Surprising, but intended by the implementation: the controller does not
+            // check whether the folder is registered or exists on disk, it simply calls
+            // CacheHelper::removeDir() and always answers with 204.
+            static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        } finally {
+            // CacheHelper::removeDir() creates the missing directory as a side effect
+            // (rsync syncs an empty directory into it), so clean it up again.
+            if (is_dir($folderPath) && (scandir($folderPath) ?: []) === ['.', '..']) {
+                rmdir($folderPath);
+            }
+        }
+    }
+}

--- a/tests/Controller/ElasticsearchControllerTest.php
+++ b/tests/Controller/ElasticsearchControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Components\Elasticsearch\ElasticsearchManager;
+use Frosh\Tools\Components\Exception\FroshToolsException;
+use Frosh\Tools\Controller\ElasticsearchController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(ElasticsearchController::class)]
+class ElasticsearchControllerTest extends IntegrationTestCase
+{
+    public function testStatusThrowsPreconditionFailedWhenElasticsearchIsDisabled(): void
+    {
+        $manager = static::getContainer()->get(ElasticsearchManager::class);
+
+        // Depending on the installation the manager is either a DisabledElasticsearchManager
+        // (shopware/elasticsearch classes missing) or the real manager with
+        // SHOPWARE_ES_ENABLED=0. Both report isEnabled() === false. When Elasticsearch
+        // is actually enabled, status() would require a running server, so we skip.
+        if ($manager->isEnabled()) {
+            static::markTestSkipped('Elasticsearch is enabled, status() requires a running Elasticsearch server');
+        }
+
+        $controller = static::getContainer()->get(ElasticsearchController::class);
+
+        try {
+            $controller->status();
+            static::fail('Expected FroshToolsException to be thrown');
+        } catch (FroshToolsException $exception) {
+            static::assertSame(Response::HTTP_PRECONDITION_FAILED, $exception->getStatusCode());
+            static::assertSame('FROSH_TOOLS__ELASTICSEARCH_DISABLED', $exception->getErrorCode());
+        }
+    }
+}

--- a/tests/Controller/ExtensionFilesControllerTest.php
+++ b/tests/Controller/ExtensionFilesControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Components\ExtensionChecksum\ExtensionFileHashService;
+use Frosh\Tools\Components\ExtensionChecksum\Struct\ExtensionChecksumCheckResult;
+use Frosh\Tools\Controller\ExtensionFilesController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(ExtensionFilesController::class)]
+#[CoversClass(ExtensionChecksumCheckResult::class)]
+class ExtensionFilesControllerTest extends IntegrationTestCase
+{
+    private const RESULT_FIELDS = [
+        'fileMissing',
+        'wrongVersion',
+        'wrongExtensionVersion',
+        'checkFailed',
+        'newFiles',
+        'changedFiles',
+        'missingFiles',
+    ];
+
+    public function testListExtensionFilesReturnsSuccessAndStructuredResults(): void
+    {
+        $controller = static::getContainer()->get(ExtensionFilesController::class);
+
+        $response = $controller->listExtensionFiles(Context::createDefaultContext());
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($data);
+        static::assertArrayHasKey('success', $data);
+        static::assertIsBool($data['success']);
+        static::assertArrayHasKey('extensionResults', $data);
+        static::assertIsArray($data['extensionResults']);
+
+        // The controller only lists extensions whose check result is not OK,
+        // so success is true exactly when there are no results.
+        static::assertSame($data['extensionResults'] === [], $data['success']);
+
+        foreach ($data['extensionResults'] as $extensionName => $result) {
+            static::assertIsString($extensionName);
+            static::assertIsArray($result, sprintf('Result of extension "%s" should be an object', $extensionName));
+
+            foreach (self::RESULT_FIELDS as $field) {
+                static::assertArrayHasKey($field, $result, sprintf('Result of extension "%s" misses field "%s"', $extensionName, $field));
+            }
+        }
+
+        $this->assertFroshToolsResultPresence($data['extensionResults']);
+    }
+
+    /**
+     * FroshTools itself is installed by the test bootstrapper, but it only appears in
+     * extensionResults when its checksum check is not OK. A missing checksum.json only
+     * sets "fileMissing", which ExtensionChecksumCheckResult::isExtensionOk() ignores,
+     * so presence depends on the environment and is asserted conditionally here.
+     *
+     * @param array<string, mixed> $extensionResults
+     */
+    private function assertFroshToolsResultPresence(array $extensionResults): void
+    {
+        $context = Context::createDefaultContext();
+
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('name', 'FroshTools'));
+        $froshTools = static::getContainer()->get('plugin.repository')->search($criteria, $context)->getEntities()->first();
+
+        static::assertInstanceOf(PluginEntity::class, $froshTools, 'FroshTools plugin should be installed by the test bootstrapper');
+
+        try {
+            $checkResult = static::getContainer()->get(ExtensionFileHashService::class)->checkExtensionForChanges($froshTools);
+            $extensionOk = $checkResult->isExtensionOk();
+        } catch (\Exception) {
+            // The controller catches exceptions and reports the extension with checkFailed=true
+            $extensionOk = false;
+        }
+
+        if ($extensionOk) {
+            static::assertArrayNotHasKey('FroshTools', $extensionResults);
+        } else {
+            static::assertArrayHasKey('FroshTools', $extensionResults);
+
+            foreach (self::RESULT_FIELDS as $field) {
+                static::assertArrayHasKey($field, $extensionResults['FroshTools']);
+            }
+        }
+    }
+}

--- a/tests/Controller/FeatureFlagControllerTest.php
+++ b/tests/Controller/FeatureFlagControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Controller\FeatureFlagController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(FeatureFlagController::class)]
+class FeatureFlagControllerTest extends IntegrationTestCase
+{
+    public function testListReturnsActiveFlagsFirstSortedByName(): void
+    {
+        $controller = static::getContainer()->get(FeatureFlagController::class);
+        $response = $controller->list();
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $flags = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertIsArray($flags);
+        static::assertNotEmpty($flags);
+
+        foreach ($flags as $flag) {
+            static::assertIsArray($flag);
+            static::assertArrayHasKey('flag', $flag);
+            static::assertIsString($flag['flag']);
+            static::assertArrayHasKey('active', $flag);
+            static::assertIsBool($flag['active']);
+        }
+
+        $sorted = $flags;
+        usort($sorted, static fn (array $a, array $b): int => [$b['active'], $a['flag']] <=> [$a['active'], $b['flag']]);
+
+        static::assertSame(
+            array_column($sorted, 'flag'),
+            array_column($flags, 'flag'),
+            'Feature flags should be sorted by active state descending, then flag name ascending'
+        );
+    }
+}

--- a/tests/Controller/HealthControllerTest.php
+++ b/tests/Controller/HealthControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Components\Health\SettingsResult;
+use Frosh\Tools\Controller\HealthController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+#[CoversClass(HealthController::class)]
+class HealthControllerTest extends IntegrationTestCase
+{
+    private const VALID_STATES = [
+        SettingsResult::GREEN,
+        SettingsResult::WARNING,
+        SettingsResult::ERROR,
+        SettingsResult::INFO,
+    ];
+
+    private HealthController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = static::getContainer()->get(HealthController::class);
+    }
+
+    public function testStatusReturnsCollectionWithKnownCheckers(): void
+    {
+        $response = $this->controller->status();
+
+        static::assertSame(200, $response->getStatusCode());
+
+        $entries = $this->decodeAndAssertResultList($response);
+
+        $ids = array_column($entries, 'id');
+        static::assertContains('queue', $ids);
+        static::assertContains('scheduled_task', $ids);
+        static::assertContains('system-time', $ids);
+    }
+
+    public function testPerformanceStatusReturnsValidResultList(): void
+    {
+        $response = $this->controller->performanceStatus();
+
+        static::assertSame(200, $response->getStatusCode());
+
+        $this->decodeAndAssertResultList($response);
+    }
+
+    public function testPingStatusReturnsCachedResponse(): void
+    {
+        $cachePool = static::getContainer()->get('cache.object');
+        static::assertInstanceOf(CacheItemPoolInterface::class, $cachePool);
+        $cachePool->deleteItem('health-ping');
+
+        $first = $this->controller->pingStatus();
+        $second = $this->controller->pingStatus();
+
+        static::assertSame(200, $first->getStatusCode());
+        static::assertSame(200, $second->getStatusCode());
+        static::assertSame($first->getContent(), $second->getContent());
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function decodeAndAssertResultList(JsonResponse $response): array
+    {
+        $entries = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($entries);
+        static::assertNotEmpty($entries);
+        static::assertSame(range(0, \count($entries) - 1), array_keys($entries), 'Response should be a JSON list');
+
+        foreach ($entries as $entry) {
+            static::assertIsArray($entry);
+            static::assertArrayHasKey('id', $entry);
+            static::assertArrayHasKey('state', $entry);
+            static::assertContains($entry['state'], self::VALID_STATES);
+        }
+
+        return $entries;
+    }
+}

--- a/tests/Controller/LogControllerTest.php
+++ b/tests/Controller/LogControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Controller\LogController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(LogController::class)]
+class LogControllerTest extends IntegrationTestCase
+{
+    private LogController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = static::getContainer()->get(LogController::class);
+    }
+
+    public function testGetLogFilesReturnsListOfLogFiles(): void
+    {
+        $response = $this->controller->getLogFiles();
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $files = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertIsArray($files);
+
+        foreach ($files as $file) {
+            static::assertIsArray($file);
+            static::assertArrayHasKey('name', $file);
+            static::assertIsString($file['name']);
+        }
+    }
+
+    public function testGetLogReturnsEntriesWithFileSizeHeader(): void
+    {
+        $files = json_decode((string) $this->controller->getLogFiles()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        if ($files === []) {
+            static::markTestSkipped('No log files present in the kernel logs dir');
+        }
+
+        $request = new Request(['file' => $files[0]['name'], 'offset' => 0]);
+        $response = $this->controller->getLog($request);
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        static::assertTrue($response->headers->has('file-size'));
+
+        $entries = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertIsArray($entries);
+
+        foreach ($entries as $entry) {
+            static::assertArrayHasKey('message', $entry);
+            static::assertArrayHasKey('channel', $entry);
+            static::assertArrayHasKey('date', $entry);
+            static::assertArrayHasKey('level', $entry);
+        }
+    }
+}

--- a/tests/Controller/QueueControllerIntegrationTest.php
+++ b/tests/Controller/QueueControllerIntegrationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Controller\QueueController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(QueueController::class)]
+class QueueControllerIntegrationTest extends IntegrationTestCase
+{
+    private QueueController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = static::getContainer()->get(QueueController::class);
+    }
+
+    public function testTransportsReturnsConfiguredTransports(): void
+    {
+        $response = $this->controller->transports();
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $transports = $this->decodeResponse($response);
+
+        static::assertNotEmpty($transports, 'At least one messenger transport should be configured');
+
+        $names = array_column($transports, 'name');
+        static::assertContains('async', $names, 'The default "async" transport should be present');
+
+        foreach ($transports as $transport) {
+            foreach (['name', 'type', 'size', 'oldestMessageAgeSeconds', 'workerLastSeenSeconds', 'browsable', 'requeuesOnBrowse', 'removable', 'retryable', 'purgeable'] as $key) {
+                static::assertArrayHasKey($key, $transport);
+            }
+
+            static::assertIsString($transport['name']);
+            static::assertIsString($transport['type']);
+        }
+    }
+
+    public function testListReturnsQueueList(): void
+    {
+        $response = $this->controller->list();
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $list = $this->decodeResponse($response);
+
+        foreach ($list as $entry) {
+            static::assertArrayHasKey('name', $entry);
+            static::assertArrayHasKey('size', $entry);
+        }
+    }
+
+    public function testMessagesReturnsMessageOverviewForTransport(): void
+    {
+        $response = $this->controller->messages('async', new Request(['limit' => 10]));
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $data = $this->decodeResponse($response);
+
+        foreach (['transport', 'type', 'size', 'messages'] as $key) {
+            static::assertArrayHasKey($key, $data);
+        }
+
+        static::assertSame('async', $data['transport']);
+        static::assertIsArray($data['messages']);
+    }
+
+    public function testMessagesWithUnknownTransportReturns404(): void
+    {
+        $response = $this->controller->messages('does-not-exist', new Request(['limit' => 10]));
+
+        $this->assertUnknownTransportResponse($response);
+    }
+
+    public function testDeleteMessageWithUnknownTransportReturns404(): void
+    {
+        $response = $this->controller->deleteMessage('does-not-exist', '1');
+
+        $this->assertUnknownTransportResponse($response);
+    }
+
+    public function testRetryMessageWithUnknownTransportReturns404(): void
+    {
+        $response = $this->controller->retryMessage('does-not-exist', '1');
+
+        $this->assertUnknownTransportResponse($response);
+    }
+
+    private function assertUnknownTransportResponse(JsonResponse $response): void
+    {
+        static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+
+        $body = $this->decodeResponse($response);
+        static::assertArrayHasKey('error', $body);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function decodeResponse(JsonResponse $response): array
+    {
+        return json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Controller/ScheduledTaskControllerTest.php
+++ b/tests/Controller/ScheduledTaskControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Controller\ScheduledTaskController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(ScheduledTaskController::class)]
+class ScheduledTaskControllerTest extends IntegrationTestCase
+{
+    private ScheduledTaskController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = static::getContainer()->get(ScheduledTaskController::class);
+    }
+
+    public function testDeactivateTaskSetsStatusInactive(): void
+    {
+        $task = $this->fetchAnyTask();
+        $context = Context::createDefaultContext();
+
+        $response = $this->controller->deactivateTask($task->getId(), $context);
+
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+
+        $reloaded = $this->reloadTask($task->getId(), $context);
+        static::assertSame(ScheduledTaskDefinition::STATUS_INACTIVE, $reloaded->getStatus());
+    }
+
+    public function testScheduleTaskImmediatelyMovesNextExecutionTimeToNow(): void
+    {
+        $task = $this->fetchAnyTask();
+        $context = Context::createDefaultContext();
+
+        // In the HTTP flow the JsonRequestTransformerListener decodes the JSON body
+        // into the request parameter bag, so parameters are passed directly here.
+        $request = new Request([], ['immediately' => true]);
+        $response = $this->controller->scheduleTask($request, $task->getId(), $context);
+
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+
+        $reloaded = $this->reloadTask($task->getId(), $context);
+        static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $reloaded->getStatus());
+
+        $nextExecutionTime = $reloaded->getNextExecutionTime();
+        static::assertNotNull($nextExecutionTime);
+        static::assertLessThanOrEqual(time(), $nextExecutionTime->getTimestamp());
+    }
+
+    public function testScheduleTaskWithUnknownIdReturns404(): void
+    {
+        $response = $this->controller->scheduleTask(new Request(), Uuid::randomHex(), Context::createDefaultContext());
+
+        static::assertInstanceOf(JsonResponse::class, $response);
+        static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertIsArray($body);
+        static::assertArrayHasKey('error', $body);
+    }
+
+    private function fetchAnyTask(): ScheduledTaskEntity
+    {
+        $task = static::getContainer()->get('scheduled_task.repository')
+            ->search((new Criteria())->setLimit(1), Context::createDefaultContext())
+            ->getEntities()
+            ->first();
+
+        if (!$task instanceof ScheduledTaskEntity) {
+            static::markTestSkipped('No scheduled tasks available in the database');
+        }
+
+        return $task;
+    }
+
+    private function reloadTask(string $id, Context $context): ScheduledTaskEntity
+    {
+        $task = static::getContainer()->get('scheduled_task.repository')
+            ->search(new Criteria([$id]), $context)
+            ->getEntities()
+            ->first();
+
+        static::assertInstanceOf(ScheduledTaskEntity::class, $task);
+
+        return $task;
+    }
+}

--- a/tests/Controller/SecurityControllerTest.php
+++ b/tests/Controller/SecurityControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Controller\SecurityController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\HttpFoundation\Request;
+
+#[CoversClass(SecurityController::class)]
+class SecurityControllerTest extends IntegrationTestCase
+{
+    private SecurityController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = static::getContainer()->get(SecurityController::class);
+    }
+
+    public function testStatusReturnsSummaryAndFindings(): void
+    {
+        $response = $this->controller->status();
+
+        static::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($data);
+        static::assertArrayHasKey('summary', $data);
+        static::assertArrayHasKey('findings', $data);
+
+        static::assertIsArray($data['summary']);
+        foreach (['critical', 'high', 'medium', 'low', 'unknown', 'ok'] as $severity) {
+            static::assertArrayHasKey($severity, $data['summary']);
+            static::assertIsInt($data['summary'][$severity]);
+        }
+
+        static::assertIsArray($data['findings']);
+        foreach ($data['findings'] as $finding) {
+            static::assertIsArray($finding);
+            static::assertArrayHasKey('id', $finding);
+            static::assertArrayHasKey('severity', $finding);
+            static::assertArrayHasKey('category', $finding);
+        }
+    }
+
+    public function testSbomReturnsCycloneDxJsonAttachment(): void
+    {
+        $response = $this->controller->sbom(new Request());
+
+        static::assertSame(200, $response->getStatusCode());
+        static::assertSame('application/vnd.cyclonedx+json', $response->headers->get('Content-Type'));
+
+        $contentDisposition = $response->headers->get('Content-Disposition');
+        static::assertNotNull($contentDisposition);
+        static::assertStringContainsString('attachment', $contentDisposition);
+
+        $bom = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        static::assertIsArray($bom);
+        static::assertSame('CycloneDX', $bom['bomFormat'] ?? null);
+    }
+
+    public function testSbomWithIncludeDevIncludesDevPackages(): void
+    {
+        $withoutDev = json_decode((string) $this->controller->sbom(new Request())->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $withDev = json_decode((string) $this->controller->sbom(new Request(['includeDev' => '1']))->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($withDev);
+        static::assertSame('CycloneDX', $withDev['bomFormat'] ?? null);
+
+        static::assertIsArray($withoutDev['components'] ?? null);
+        static::assertIsArray($withDev['components'] ?? null);
+        static::assertNotEmpty($withDev['components']);
+        static::assertGreaterThanOrEqual(\count($withoutDev['components']), \count($withDev['components']));
+    }
+}

--- a/tests/Controller/ShopmonControllerTest.php
+++ b/tests/Controller/ShopmonControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Controller\ShopmonController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(ShopmonController::class)]
+class ShopmonControllerTest extends IntegrationTestCase
+{
+    private const INTEGRATION_ID = 'c2f0a1d4b6e84f309a5d7c1e8b2f4a60';
+    private const CONFIG_KEY = 'FroshTools.config.shopmonIntegrationData';
+
+    private ShopmonController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = static::getContainer()->get(ShopmonController::class);
+    }
+
+    public function testStatusReturnsNotConfigured(): void
+    {
+        $context = Context::createDefaultContext();
+
+        // Ensure a clean slate even if the installation was configured before
+        $this->controller->remove($context);
+
+        $status = $this->decodeResponse($this->controller->status($context));
+
+        static::assertSame(['configured' => false], $status);
+    }
+
+    public function testSetupCreatesIntegrationAndConfiguration(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $status = $this->decodeResponse($this->controller->setup($context));
+
+        static::assertTrue($status['configured']);
+        static::assertNotEmpty($status['clientId']);
+        static::assertNotEmpty($status['clientSecret']);
+
+        $integration = static::getContainer()->get('integration.repository')
+            ->search(new Criteria([self::INTEGRATION_ID]), $context)
+            ->getEntities()
+            ->first();
+
+        static::assertNotNull($integration, 'Setup should create the shopmon integration');
+
+        $configValue = static::getContainer()->get(SystemConfigService::class)->getString(self::CONFIG_KEY);
+        static::assertNotSame('', $configValue, 'Setup should persist the integration data in the system config');
+    }
+
+    public function testSetupIsIdempotent(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $first = $this->decodeResponse($this->controller->setup($context));
+        $second = $this->decodeResponse($this->controller->setup($context));
+
+        static::assertTrue($first['configured']);
+        static::assertTrue($second['configured']);
+
+        $result = static::getContainer()->get('integration.repository')
+            ->search(new Criteria([self::INTEGRATION_ID]), $context);
+
+        static::assertSame(1, $result->getTotal(), 'Calling setup twice must not duplicate the integration');
+    }
+
+    public function testRemoveDeletesIntegrationAndConfiguration(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $this->controller->setup($context);
+
+        $response = $this->controller->remove($context);
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+
+        $status = $this->decodeResponse($this->controller->status($context));
+        static::assertSame(['configured' => false], $status);
+
+        $integration = static::getContainer()->get('integration.repository')
+            ->search(new Criteria([self::INTEGRATION_ID]), $context)
+            ->getEntities()
+            ->first();
+
+        static::assertNull($integration, 'Remove should delete the shopmon integration');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeResponse(JsonResponse $response): array
+    {
+        return json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Controller/StatisticsControllerTest.php
+++ b/tests/Controller/StatisticsControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Controller\StatisticsController;
+use Frosh\Tools\Tests\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(StatisticsController::class)]
+class StatisticsControllerTest extends IntegrationTestCase
+{
+    private StatisticsController $controller;
+
+    protected function setUp(): void
+    {
+        $this->controller = static::getContainer()->get(StatisticsController::class);
+    }
+
+    public function testDatabaseStatisticsReturnsServerTablesAndGlobalStatus(): void
+    {
+        $response = $this->controller->databaseStatistics();
+
+        static::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($data);
+        static::assertArrayHasKey('server', $data);
+        static::assertArrayHasKey('tables', $data);
+        static::assertArrayHasKey('globalStatus', $data);
+
+        static::assertIsArray($data['server']);
+        static::assertArrayHasKey('version', $data['server']);
+        static::assertIsString($data['server']['version']);
+        static::assertNotSame('', $data['server']['version']);
+
+        static::assertIsArray($data['tables']);
+        static::assertNotEmpty($data['tables']);
+
+        $names = array_column($data['tables'], 'name');
+        static::assertContains('product', $names);
+    }
+
+    public function testCacheStatisticsContainsAdapterKeys(): void
+    {
+        $response = $this->controller->cacheStatistics();
+
+        static::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($data);
+        foreach (['opcache', 'apcu', 'redis', 'fpm'] as $key) {
+            static::assertArrayHasKey($key, $data);
+        }
+    }
+}

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+
+/**
+ * Base class for integration tests that need the real kernel, container and database.
+ *
+ * Every test runs inside a database transaction which is rolled back afterwards,
+ * so tests must not use statements that cause implicit commits (e.g. TRUNCATE).
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+    use KernelTestBehaviour;
+    use DatabaseTransactionBehaviour;
+}


### PR DESCRIPTION
## Summary

The test suite so far only had kernel-free unit tests. This adds proper **integration tests** that boot the Shopware kernel and run against the real DI container (compiler passes, tagged iterators, autowiring) and a real MySQL database.

- New shared base class `tests/IntegrationTestCase.php` using Shopware's `KernelTestBehaviour` + `DatabaseTransactionBehaviour` — every test runs in a DB transaction that is rolled back afterwards (no `TRUNCATE` anywhere, so isolation holds). Works on 6.6 and 6.7/trunk (the removed `KernelTestCase` is not used).
- No changes to `phpunit.xml`, `composer.json` or CI needed — the existing bootstrapper and the phpunit matrix already provide Shopware + MySQL.

## Coverage added

| Area | Tests |
|---|---|
| `HealthController` | health/performance status collections incl. all tagged checkers, cached ping endpoint |
| `SecurityController` | findings summary, CycloneDX SBOM download from the real `composer.lock` |
| `StatisticsController` + `DatabaseStatisticsService` | server info, table statistics, global status against live MySQL |
| `ShopmonController` | full setup → idempotent re-setup → remove lifecycle |
| `ScheduledTaskController` | deactivate / schedule immediately / unknown id 404 |
| `QueueController` | transports, queue list, message browsing, unknown-transport 404s |
| `CacheController` | adapter listing, clearing unknown folders |
| `ElasticsearchController` | 412 when Elasticsearch is disabled |
| `ExtensionFilesController` | checksum result structure |
| `LogController` | log file listing and reading |
| `FeatureFlagController` | flag listing and sorting |
| `QueueChecker` / `TaskChecker` | info/green/warning states driven by seeded DB rows |

## Notes

- Assertions are deliberately network-tolerant (structure and ids, never a green state for checks that call packagist/endoflife.date/github) so the suite passes offline.
- Assertions avoid version-specific expectations to hold on both 6.6.x and trunk.

## Test plan

- [x] `composer phpunit` locally: 57 tests, 2634 assertions, green across repeated runs (no cross-test pollution)
- [ ] CI matrix (6.6.x, trunk)