### PR TITLE
fix: clarify Redis TagAware check targets HTTP cache only (#245)

### DIFF
--- a/src/Components/Health/Checker/PerformanceChecker/RedisTagAwareChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/RedisTagAwareChecker.php
@@ -10,6 +10,15 @@ use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
 
+/**
+ * Recommends RedisTagAware for the HTTP cache pool only.
+ *
+ * Shopware's HTTP cache relies on tag-based invalidation. The plain Redis adapter
+ * stores tags inefficiently; RedisTagAwareAdapter is the recommended backend.
+ *
+ * Other pools (e.g. cache.object) may intentionally use plain Redis — this checker
+ * must not warn about those. See https://github.com/FriendsOfShopware/FroshTools/issues/245
+ */
 class RedisTagAwareChecker implements PerformanceCheckerInterface, CheckerInterface
 {
     public function __construct(
@@ -19,8 +28,14 @@ class RedisTagAwareChecker implements PerformanceCheckerInterface, CheckerInterf
 
     public function collect(HealthCollection $collection): void
     {
+        // HTTP cache pool only — not cache.object / cache.app / system.
+        if (!$this->cacheRegistry->has('cache.http')) {
+            return;
+        }
+
         $httpCacheType = $this->cacheRegistry->get('cache.http')->getType();
 
+        // Already TagAware, or not Redis at all (filesystem, array, …).
         if (!\str_starts_with($httpCacheType, CacheAdapter::TYPE_REDIS)
             || \str_starts_with($httpCacheType, CacheAdapter::TYPE_REDIS_TAG_AWARE)) {
             return;
@@ -29,8 +44,8 @@ class RedisTagAwareChecker implements PerformanceCheckerInterface, CheckerInterf
         $collection->add(
             SettingsResult::warning(
                 'redis-tag-aware',
-                'Redis adapter should be TagAware',
-                CacheAdapter::TYPE_REDIS,
+                'HTTP cache (cache.http) Redis adapter should be TagAware',
+                $httpCacheType !== '' ? $httpCacheType : CacheAdapter::TYPE_REDIS,
                 CacheAdapter::TYPE_REDIS_TAG_AWARE,
             ),
         );

--- a/src/Components/Health/Checker/PerformanceChecker/RedisTagAwareChecker.php
+++ b/src/Components/Health/Checker/PerformanceChecker/RedisTagAwareChecker.php
@@ -45,7 +45,7 @@ class RedisTagAwareChecker implements PerformanceCheckerInterface, CheckerInterf
             SettingsResult::warning(
                 'redis-tag-aware',
                 'HTTP cache (cache.http) Redis adapter should be TagAware',
-                $httpCacheType !== '' ? $httpCacheType : CacheAdapter::TYPE_REDIS,
+                $httpCacheType,
                 CacheAdapter::TYPE_REDIS_TAG_AWARE,
             ),
         );

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-index/recommendations.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-index/recommendations.js
@@ -244,8 +244,9 @@ export default {
     },
     'redis-tag-aware': {
         description:
-            'The HTTP cache uses the plain Redis adapter, which stores cache tags inefficiently. The TagAware Redis adapter is optimised for tag-based invalidation as used by Shopware.',
+            'This check looks at the HTTP cache pool (cache.http) only — not cache.object or other pools. The plain Redis adapter stores cache tags inefficiently; RedisTagAware is optimised for Shopware’s tag-based HTTP cache invalidation. Using plain Redis for cache.object on purpose is fine and will not trigger this warning.',
         solution:
-            'Switch the cache adapter to the TagAware Redis adapter ("redis++").',
+            'Configure the HTTP cache pool (or the default app adapter that cache.http inherits) to use the TagAware Redis adapter.',
+        code: '# config/packages/cache.yaml\nframework:\n    cache:\n        app: cache.adapter.redis_tag_aware\n        default_redis_provider: \'redis://localhost\'\n        # optional: keep object cache on plain Redis if you prefer\n        pools:\n            cache.object:\n                adapter: cache.adapter.redis',
     },
 };

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-index/recommendations.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-index/recommendations.js
@@ -247,6 +247,6 @@ export default {
             'This check looks at the HTTP cache pool (cache.http) only — not cache.object or other pools. The plain Redis adapter stores cache tags inefficiently; RedisTagAware is optimised for Shopware’s tag-based HTTP cache invalidation. Using plain Redis for cache.object on purpose is fine and will not trigger this warning.',
         solution:
             'Configure the HTTP cache pool (or the default app adapter that cache.http inherits) to use the TagAware Redis adapter.',
-        code: '# config/packages/cache.yaml\nframework:\n    cache:\n        app: cache.adapter.redis_tag_aware\n        default_redis_provider: \'redis://localhost\'\n        # optional: keep object cache on plain Redis if you prefer\n        pools:\n            cache.object:\n                adapter: cache.adapter.redis',
+        code: "# config/packages/cache.yaml\nframework:\n    cache:\n        app: cache.adapter.redis_tag_aware\n        default_redis_provider: 'redis://localhost'\n        # optional: keep object cache on plain Redis if you prefer\n        pools:\n            cache.object:\n                adapter: cache.adapter.redis",
     },
 };

--- a/tests/Components/Health/Checker/PerformanceChecker/RedisTagAwareCheckerTest.php
+++ b/tests/Components/Health/Checker/PerformanceChecker/RedisTagAwareCheckerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\Health\Checker\PerformanceChecker;
+
+use Frosh\Tools\Components\CacheAdapter;
+use Frosh\Tools\Components\CacheRegistry;
+use Frosh\Tools\Components\Health\Checker\PerformanceChecker\RedisTagAwareChecker;
+use Frosh\Tools\Components\Health\HealthCollection;
+use Frosh\Tools\Components\Health\SettingsResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RedisTagAwareChecker::class)]
+class RedisTagAwareCheckerTest extends TestCase
+{
+    public function testDoesNothingWhenHttpPoolMissing(): void
+    {
+        $registry = $this->createMock(CacheRegistry::class);
+        $registry->method('has')->with('cache.http')->willReturn(false);
+        $registry->expects(static::never())->method('get');
+
+        $collection = new HealthCollection();
+        (new RedisTagAwareChecker($registry))->collect($collection);
+
+        static::assertCount(0, $collection);
+    }
+
+    public function testDoesNothingWhenHttpUsesTagAwareRedis(): void
+    {
+        $collection = $this->collectWithHttpType(CacheAdapter::TYPE_REDIS_TAG_AWARE . ' 7.2.0');
+
+        static::assertCount(0, $collection);
+    }
+
+    public function testDoesNothingWhenHttpIsNotRedis(): void
+    {
+        $collection = $this->collectWithHttpType(CacheAdapter::TYPE_FILESYSTEM);
+
+        static::assertCount(0, $collection);
+    }
+
+    public function testDoesNothingWhenObjectWouldBePlainRedisButHttpIsTagAware(): void
+    {
+        // Regression for #245: plain Redis on cache.object must not trigger this check.
+        // The checker only reads cache.http — TagAware HTTP + plain object is valid.
+        $http = $this->createMock(CacheAdapter::class);
+        $http->method('getType')->willReturn(CacheAdapter::TYPE_REDIS_TAG_AWARE . ' 7.2.0');
+
+        $registry = $this->createMock(CacheRegistry::class);
+        $registry->method('has')->with('cache.http')->willReturn(true);
+        $registry->method('get')->with('cache.http')->willReturn($http);
+
+        $collection = new HealthCollection();
+        (new RedisTagAwareChecker($registry))->collect($collection);
+
+        static::assertCount(0, $collection);
+    }
+
+    public function testWarnsWhenHttpUsesPlainRedis(): void
+    {
+        $collection = $this->collectWithHttpType(CacheAdapter::TYPE_REDIS . ' 7.2.0');
+
+        static::assertCount(1, $collection);
+        /** @var SettingsResult $result */
+        $result = $collection->first();
+        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertSame('redis-tag-aware', $result->id);
+        static::assertStringContainsString('cache.http', $result->getVars()['snippet']);
+        static::assertStringContainsString('HTTP cache', $result->getVars()['snippet']);
+        static::assertStringStartsWith(CacheAdapter::TYPE_REDIS, $result->current);
+        static::assertSame(CacheAdapter::TYPE_REDIS_TAG_AWARE, $result->recommended);
+    }
+
+    private function collectWithHttpType(string $type): HealthCollection
+    {
+        $http = $this->createMock(CacheAdapter::class);
+        $http->method('getType')->willReturn($type);
+
+        $registry = $this->createMock(CacheRegistry::class);
+        $registry->method('has')->with('cache.http')->willReturn(true);
+        $registry->method('get')->with('cache.http')->willReturn($http);
+
+        $collection = new HealthCollection();
+        (new RedisTagAwareChecker($registry))->collect($collection);
+
+        return $collection;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the confusing UX around [#245](https://github.com/FriendsOfShopware/FroshTools/issues/245).

### Background
`RedisTagAwareChecker` has always inspected **`cache.http` only** (as @tinect noted). The reporter’s config intentionally keeps **`cache.object` on plain Redis** while using TagAware elsewhere. The warning label still read:

> Redis adapter should be TagAware

…which looks like a global/object-cache problem even when `cache.http` is the only pool under scrutiny.

### Changes
- Result snippet → **`HTTP cache (cache.http) Redis adapter should be TagAware`**
- Show the actual detected type as `current` (includes Redis version when available)
- Skip cleanly if `cache.http` is not registered
- Admin recommendation modal: explicit “this is not about cache.object” + example YAML that keeps plain Redis for object cache
- Unit tests for missing pool / TagAware / plain Redis / filesystem

### Out of scope
Changing *which* pool is checked (still HTTP cache — that remains the correct production recommendation). No behaviour change for shops already on TagAware HTTP cache.

## Test plan
- [x] Standalone unit assertions against the checker (9/9)
- [ ] CI phpunit on PR