### PR TITLE
feat: configurable queue monitoring for QueueChecker (#269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,10 @@ frosh_tools:
 Plugin system config (Admin → Extensions → Frosh Tools):
 
 - **Monitor mail address** — recipient for `frosh:monitor`
-- **Queue grace time** (minutes) — when a queue is considered stuck
+- **Default queue grace time** (minutes) — when a pending message is considered stuck
+- **Exclude failed queues** — ignore transports whose name contains `failed` (default on)
+- **Queues to monitor** — optional allowlist, e.g. `async, low_priority`
+- **Per-queue grace times** — optional overrides, e.g. `async:15, low_priority:60`
 - **Task grace time** (minutes) — when a scheduled task is considered stuck
 
 JSON Schema for IDE validation: [`frosh-tools-schema.json`](frosh-tools-schema.json).

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -33,9 +33,9 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
         $graceByQueue = $this->parseGraceMap($this->configService->getString(self::CONFIG_GRACE_TIMES));
 
         $snippet = 'Open Queues';
-        $row = $this->fetchOldestPendingMessage($excludeFailed, $queues);
+        $pendingByQueue = $this->fetchOldestPendingMessagePerQueue($excludeFailed, $queues);
 
-        if ($row === null) {
+        if ($pendingByQueue === []) {
             $collection->add(SettingsResult::info(
                 'queue',
                 $snippet,
@@ -46,13 +46,11 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
             return;
         }
 
-        $queueName = (string) $row['queue_name'];
-        $grace = $graceByQueue[$queueName] ?? $defaultGrace;
-        $recommended = \sprintf('max %d mins', $grace);
-        $ageMinutes = $this->ageInMinutes((string) $row['available_at']);
-        $current = \sprintf('%d mins (%s)', $ageMinutes, $queueName);
+        $worst = $this->selectWorstQueue($pendingByQueue, $graceByQueue, $defaultGrace);
+        $recommended = \sprintf('max %d mins', $worst['grace']);
+        $current = \sprintf('%d mins (%s)', $worst['ageMinutes'], $worst['queueName']);
 
-        if ($ageMinutes > $grace) {
+        if ($worst['overdue']) {
             $collection->add(SettingsResult::warning('queue', $snippet, $current, $recommended));
 
             return;
@@ -64,16 +62,18 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
     /**
      * @param list<string> $queues
      *
-     * @return array{available_at: string, queue_name: string}|null
+     * @return list<array{available_at: string, queue_name: string}>
      */
-    private function fetchOldestPendingMessage(bool $excludeFailed, array $queues): ?array
+    private function fetchOldestPendingMessagePerQueue(bool $excludeFailed, array $queues): array
     {
+        // One row per queue (oldest pending message). Evaluating each queue against its
+        // own grace avoids masking a tighter queue behind an older message on a looser one.
         $query = $this->connection->createQueryBuilder()
-            ->select('available_at', 'queue_name')
+            ->select('queue_name', 'MIN(available_at) AS available_at')
             ->from('messenger_messages')
             ->where('available_at <= UTC_TIMESTAMP()')
-            ->orderBy('available_at', 'ASC')
-            ->setMaxResults(1);
+            ->groupBy('queue_name')
+            ->orderBy('available_at', 'ASC');
 
         if ($excludeFailed) {
             // Symfony failure transport names typically contain "failed" (e.g. async_failed).
@@ -88,10 +88,76 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
                 ->setParameter('queues', $queues, ArrayParameterType::STRING);
         }
 
-        /** @var array{available_at: string, queue_name: string}|false $row */
-        $row = $query->fetchAssociative();
+        /** @var list<array{available_at: string, queue_name: string}> $rows */
+        $rows = $query->fetchAllAssociative();
 
-        return \is_array($row) ? $row : null;
+        return $rows;
+    }
+
+    /**
+     * Prefer any overdue queue (highest minutes-over-grace); otherwise the oldest pending age.
+     *
+     * @param list<array{available_at: string, queue_name: string}> $pendingByQueue
+     * @param array<string, int> $graceByQueue
+     *
+     * @return array{queueName: string, ageMinutes: int, grace: int, overdue: bool}
+     */
+    private function selectWorstQueue(array $pendingByQueue, array $graceByQueue, int $defaultGrace): array
+    {
+        $worst = null;
+
+        foreach ($pendingByQueue as $row) {
+            $queueName = (string) $row['queue_name'];
+            $grace = $graceByQueue[$queueName] ?? $defaultGrace;
+            $ageMinutes = $this->ageInMinutes((string) $row['available_at']);
+            $overdue = $ageMinutes > $grace;
+            $overBy = $overdue ? $ageMinutes - $grace : 0;
+
+            $candidate = [
+                'queueName' => $queueName,
+                'ageMinutes' => $ageMinutes,
+                'grace' => $grace,
+                'overdue' => $overdue,
+                'overBy' => $overBy,
+            ];
+
+            if ($worst === null) {
+                $worst = $candidate;
+                continue;
+            }
+
+            // Overdue always beats healthy.
+            if ($candidate['overdue'] && !$worst['overdue']) {
+                $worst = $candidate;
+                continue;
+            }
+            if (!$candidate['overdue'] && $worst['overdue']) {
+                continue;
+            }
+
+            // Both overdue: the one furthest past its own grace.
+            if ($candidate['overdue'] && $worst['overdue']) {
+                if ($candidate['overBy'] > $worst['overBy']
+                    || ($candidate['overBy'] === $worst['overBy'] && $candidate['ageMinutes'] > $worst['ageMinutes'])) {
+                    $worst = $candidate;
+                }
+                continue;
+            }
+
+            // Both healthy: report the oldest pending age for visibility.
+            if ($candidate['ageMinutes'] > $worst['ageMinutes']) {
+                $worst = $candidate;
+            }
+        }
+
+        \assert($worst !== null);
+
+        return [
+            'queueName' => $worst['queueName'],
+            'ageMinutes' => $worst['ageMinutes'],
+            'grace' => $worst['grace'],
+            'overdue' => $worst['overdue'],
+        ];
     }
 
     private function ageInMinutes(string $availableAt): int

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Components\Health\Checker\HealthChecker;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
@@ -67,27 +68,28 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
      */
     private function fetchOldestPendingMessage(bool $excludeFailed, array $queues): ?array
     {
-        $sql = 'SELECT available_at, queue_name FROM messenger_messages WHERE available_at <= UTC_TIMESTAMP()';
-        $params = [];
+        $query = $this->connection->createQueryBuilder()
+            ->select('available_at', 'queue_name')
+            ->from('messenger_messages')
+            ->where('available_at <= UTC_TIMESTAMP()')
+            ->orderBy('available_at', 'ASC')
+            ->setMaxResults(1);
 
         if ($excludeFailed) {
             // Symfony failure transport names typically contain "failed" (e.g. async_failed).
-            $sql .= ' AND queue_name NOT LIKE ?';
-            $params[] = '%failed%';
+            $query
+                ->andWhere('queue_name NOT LIKE :failedPattern')
+                ->setParameter('failedPattern', '%failed%');
         }
 
         if ($queues !== []) {
-            $placeholders = \implode(', ', \array_fill(0, \count($queues), '?'));
-            $sql .= \sprintf(' AND queue_name IN (%s)', $placeholders);
-            foreach ($queues as $queue) {
-                $params[] = $queue;
-            }
+            $query
+                ->andWhere('queue_name IN (:queues)')
+                ->setParameter('queues', $queues, ArrayParameterType::STRING);
         }
 
-        $sql .= ' ORDER BY available_at ASC LIMIT 1';
-
         /** @var array{available_at: string, queue_name: string}|false $row */
-        $row = $this->connection->fetchAssociative($sql, $params);
+        $row = $query->fetchAssociative();
 
         return \is_array($row) ? $row : null;
     }

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -127,16 +127,15 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
             }
 
             // Overdue always beats healthy.
-            if ($candidate['overdue'] && !$worst['overdue']) {
-                $worst = $candidate;
-                continue;
-            }
-            if (!$candidate['overdue'] && $worst['overdue']) {
+            if ($candidate['overdue'] !== $worst['overdue']) {
+                if ($candidate['overdue']) {
+                    $worst = $candidate;
+                }
                 continue;
             }
 
-            // Both overdue: the one furthest past its own grace.
-            if ($candidate['overdue'] && $worst['overdue']) {
+            // Same state: both overdue → furthest past grace; both healthy → oldest age.
+            if ($candidate['overdue']) {
                 if ($candidate['overBy'] > $worst['overBy']
                     || ($candidate['overBy'] === $worst['overBy'] && $candidate['ageMinutes'] > $worst['ageMinutes'])) {
                     $worst = $candidate;
@@ -144,7 +143,6 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
                 continue;
             }
 
-            // Both healthy: report the oldest pending age for visibility.
             if ($candidate['ageMinutes'] > $worst['ageMinutes']) {
                 $worst = $candidate;
             }

--- a/src/Components/Health/Checker/HealthChecker/QueueChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/QueueChecker.php
@@ -12,6 +12,12 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 class QueueChecker implements HealthCheckerInterface, CheckerInterface
 {
+    private const CONFIG_GRACE = 'FroshTools.config.monitorQueueGraceTime';
+    private const CONFIG_EXCLUDE_FAILED = 'FroshTools.config.monitorExcludeFailedQueues';
+    private const CONFIG_QUEUES = 'FroshTools.config.monitorQueues';
+    private const CONFIG_GRACE_TIMES = 'FroshTools.config.monitorQueueGraceTimes';
+    private const DEFAULT_GRACE_MINUTES = 15;
+
     public function __construct(
         private readonly Connection $connection,
         private readonly SystemConfigService $configService,
@@ -20,29 +26,127 @@ class QueueChecker implements HealthCheckerInterface, CheckerInterface
 
     public function collect(HealthCollection $collection): void
     {
-        $maxDiff = $this->configService->getInt('FroshTools.config.monitorQueueGraceTime') ?: 15;
-        $oldMessageLimit = (new \DateTimeImmutable())->modify(\sprintf('-%d minutes', $maxDiff));
+        $defaultGrace = $this->configService->getInt(self::CONFIG_GRACE) ?: self::DEFAULT_GRACE_MINUTES;
+        $excludeFailed = $this->shouldExcludeFailedQueues();
+        $queues = $this->parseCsvList($this->configService->getString(self::CONFIG_QUEUES));
+        $graceByQueue = $this->parseGraceMap($this->configService->getString(self::CONFIG_GRACE_TIMES));
 
         $snippet = 'Open Queues';
-        $recommended = \sprintf('max %d mins', $maxDiff);
+        $row = $this->fetchOldestPendingMessage($excludeFailed, $queues);
 
-        /** @var string|false $oldestMessageAt */
-        $oldestMessageAt = $this->connection->fetchOne('SELECT available_at FROM messenger_messages WHERE available_at < UTC_TIMESTAMP() ORDER BY available_at ASC LIMIT 1');
-
-        if (\is_string($oldestMessageAt)) {
-            $diff = round(abs(
-                ((new \DateTime($oldestMessageAt . ' UTC'))->getTimestamp() - $oldMessageLimit->getTimestamp()) / 60,
+        if ($row === null) {
+            $collection->add(SettingsResult::info(
+                'queue',
+                $snippet,
+                '0 mins',
+                \sprintf('max %d mins', $defaultGrace),
             ));
 
-            if ($diff > $maxDiff) {
-                $result = SettingsResult::warning('queue', $snippet, $diff . ' mins', $recommended);
-            } else {
-                $result = SettingsResult::ok('queue', $snippet, $diff . ' mins', $recommended);
-            }
-        } else {
-            $result = SettingsResult::info('queue', $snippet, 'unknown', $recommended);
+            return;
         }
 
-        $collection->add($result);
+        $queueName = (string) $row['queue_name'];
+        $grace = $graceByQueue[$queueName] ?? $defaultGrace;
+        $recommended = \sprintf('max %d mins', $grace);
+        $ageMinutes = $this->ageInMinutes((string) $row['available_at']);
+        $current = \sprintf('%d mins (%s)', $ageMinutes, $queueName);
+
+        if ($ageMinutes > $grace) {
+            $collection->add(SettingsResult::warning('queue', $snippet, $current, $recommended));
+
+            return;
+        }
+
+        $collection->add(SettingsResult::ok('queue', $snippet, $current, $recommended));
+    }
+
+    /**
+     * @param list<string> $queues
+     *
+     * @return array{available_at: string, queue_name: string}|null
+     */
+    private function fetchOldestPendingMessage(bool $excludeFailed, array $queues): ?array
+    {
+        $sql = 'SELECT available_at, queue_name FROM messenger_messages WHERE available_at <= UTC_TIMESTAMP()';
+        $params = [];
+
+        if ($excludeFailed) {
+            // Symfony failure transport names typically contain "failed" (e.g. async_failed).
+            $sql .= ' AND queue_name NOT LIKE ?';
+            $params[] = '%failed%';
+        }
+
+        if ($queues !== []) {
+            $placeholders = \implode(', ', \array_fill(0, \count($queues), '?'));
+            $sql .= \sprintf(' AND queue_name IN (%s)', $placeholders);
+            foreach ($queues as $queue) {
+                $params[] = $queue;
+            }
+        }
+
+        $sql .= ' ORDER BY available_at ASC LIMIT 1';
+
+        /** @var array{available_at: string, queue_name: string}|false $row */
+        $row = $this->connection->fetchAssociative($sql, $params);
+
+        return \is_array($row) ? $row : null;
+    }
+
+    private function ageInMinutes(string $availableAt): int
+    {
+        $available = new \DateTimeImmutable($availableAt, new \DateTimeZone('UTC'));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $seconds = \max(0, $now->getTimestamp() - $available->getTimestamp());
+
+        return (int) \floor($seconds / 60);
+    }
+
+    private function shouldExcludeFailedQueues(): bool
+    {
+        $value = $this->configService->get(self::CONFIG_EXCLUDE_FAILED);
+
+        // Default true when the setting has never been stored.
+        return $value === null ? true : (bool) $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseCsvList(string $value): array
+    {
+        if (\trim($value) === '') {
+            return [];
+        }
+
+        $parts = \array_map(\trim(...), \explode(',', $value));
+
+        return \array_values(\array_filter($parts, static fn (string $part): bool => $part !== ''));
+    }
+
+    /**
+     * Parses "async:15, low_priority:60" into queue => grace minutes.
+     *
+     * @return array<string, int>
+     */
+    private function parseGraceMap(string $value): array
+    {
+        $map = [];
+        foreach ($this->parseCsvList($value) as $entry) {
+            if (!\str_contains($entry, ':')) {
+                continue;
+            }
+
+            [$name, $minutes] = \array_map(\trim(...), \explode(':', $entry, 2));
+            if ($name === '' || !\is_numeric($minutes)) {
+                continue;
+            }
+
+            $grace = (int) $minutes;
+            if ($grace > 0) {
+                $map[$name] = $grace;
+            }
+        }
+
+        return $map;
     }
 }

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-index/recommendations.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-index/recommendations.js
@@ -21,10 +21,10 @@ export default {
     },
     queue: {
         description:
-            'Messages have been waiting in the message queue longer than the configured grace time. That almost always means no worker is consuming the queue, so asynchronous tasks (mails, indexing, …) pile up.',
+            'Messages have been waiting in a monitored messenger queue longer than the configured grace time. That almost always means no worker is consuming that queue, so asynchronous tasks (mails, indexing, …) pile up. Failed queues (names containing "failed") are ignored by default because they are usually drained manually.',
         solution:
-            'Make sure a CLI worker is running and supervised (e.g. via systemd or Supervisor) so the queue is drained continuously.',
-        code: 'bin/console messenger:consume async low_priority failed',
+            'Make sure a CLI worker is running and supervised (e.g. via systemd or Supervisor) so the queue is drained continuously. Adjust monitored queues and per-queue grace times under Settings → Extensions → Frosh Tools if needed.',
+        code: 'bin/console messenger:consume async low_priority\n# Extension config examples:\n# monitorQueues = async, low_priority\n# monitorQueueGraceTimes = async:15, low_priority:60\n# monitorExcludeFailedQueues = true',
     },
     'mysql-timezone': {
         description:

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -16,11 +16,38 @@
 
         <input-field type="int">
             <name>monitorQueueGraceTime</name>
-            <label>Scheduled queue grace time</label>
-            <label lang="de-DE">Geplante Karenzzeit der Queue</label>
-            <helpText>After X minutes a queue is considered stuck / faulty</helpText>
-            <helpText lang="de-DE">Nach X Minuten gilt eine Queue als festgefahren / fehlerhaft</helpText>
+            <label>Default queue grace time (minutes)</label>
+            <label lang="de-DE">Standard-Karenzzeit der Queue (Minuten)</label>
+            <helpText>After this many minutes a pending message is considered stuck. Used when no per-queue override matches.</helpText>
+            <helpText lang="de-DE">Nach so vielen Minuten gilt eine ausstehende Nachricht als festgefahren. Gilt, wenn kein Queue-Override greift.</helpText>
             <defaultValue>15</defaultValue>
+        </input-field>
+
+        <input-field type="bool">
+            <name>monitorExcludeFailedQueues</name>
+            <label>Exclude failed queues</label>
+            <label lang="de-DE">Failed-Queues ausschließen</label>
+            <helpText>Ignore messenger queues whose name contains "failed" (e.g. async_failed). Those are usually drained manually and would otherwise cause false positives.</helpText>
+            <helpText lang="de-DE">Ignoriert Messenger-Queues, deren Name "failed" enthält (z. B. async_failed). Diese werden meist manuell abgearbeitet und würden sonst Fehlalarme auslösen.</helpText>
+            <defaultValue>true</defaultValue>
+        </input-field>
+
+        <input-field type="text">
+            <name>monitorQueues</name>
+            <label>Queues to monitor</label>
+            <label lang="de-DE">Zu überwachende Queues</label>
+            <helpText>Optional comma-separated allowlist (e.g. async, low_priority). Leave empty to monitor all queues (except failed ones when exclusion is enabled).</helpText>
+            <helpText lang="de-DE">Optionale kommaseparierte Allowlist (z. B. async, low_priority). Leer lassen, um alle Queues zu überwachen (außer Failed-Queues, wenn der Ausschluss aktiv ist).</helpText>
+            <placeholder>async, low_priority</placeholder>
+        </input-field>
+
+        <input-field type="text">
+            <name>monitorQueueGraceTimes</name>
+            <label>Per-queue grace times</label>
+            <label lang="de-DE">Karenzzeiten pro Queue</label>
+            <helpText>Optional overrides as queue:minutes pairs (e.g. async:15, low_priority:60). Queues not listed use the default grace time.</helpText>
+            <helpText lang="de-DE">Optionale Overrides als Queue:Minuten-Paare (z. B. async:15, low_priority:60). Nicht gelistete Queues nutzen die Standard-Karenzzeit.</helpText>
+            <placeholder>async:15, low_priority:60</placeholder>
         </input-field>
 
         <input-field type="int">

--- a/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
@@ -4,26 +4,40 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Tests\Components\Health\Checker\HealthChecker;
 
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Query\QueryBuilder;
 use Frosh\Tools\Components\Health\Checker\HealthChecker\QueueChecker;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
+use Frosh\Tools\Tests\IntegrationTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
+/**
+ * Kernel + DB coverage for QueueChecker (QueryBuilder against real messenger_messages).
+ * Fast mock-based edge cases live in QueueCheckerUnitTest.
+ */
 #[CoversClass(QueueChecker::class)]
-class QueueCheckerTest extends TestCase
+class QueueCheckerTest extends IntegrationTestCase
 {
+    private QueueChecker $checker;
+
+    private Connection $connection;
+
+    private SystemConfigService $configService;
+
+    protected function setUp(): void
+    {
+        $this->checker = static::getContainer()->get(QueueChecker::class);
+        $this->connection = static::getContainer()->get(Connection::class);
+        $this->configService = static::getContainer()->get(SystemConfigService::class);
+
+        $this->connection->executeStatement('DELETE FROM messenger_messages');
+        $this->resetMonitorConfig();
+    }
+
     public function testEmptyQueueResultsInInfoState(): void
     {
-        $result = $this->collect(
-            connectionRows: false,
-            config: [],
-        );
+        $result = $this->collectQueueResult();
 
         static::assertSame(SettingsResult::INFO, $result->state);
         static::assertSame('0 mins', $result->current);
@@ -31,13 +45,9 @@ class QueueCheckerTest extends TestCase
 
     public function testOldMessageResultsInWarningState(): void
     {
-        $result = $this->collect(
-            connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
-            ],
-            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
-        );
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 2 HOUR', 'async');
+
+        $result = $this->collectQueueResult();
 
         static::assertSame(SettingsResult::WARNING, $result->state);
         static::assertStringContainsString('async', $result->current);
@@ -45,174 +55,81 @@ class QueueCheckerTest extends TestCase
 
     public function testRecentMessageWithinGracePeriodResultsInOkState(): void
     {
-        $result = $this->collect(
-            connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-1 minute', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
-            ],
-            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
-        );
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 1 MINUTE', 'async');
+
+        $result = $this->collectQueueResult();
 
         static::assertSame(SettingsResult::GREEN, $result->state);
     }
 
-    public function testMessageJustOverGraceIsWarningNotDoubleGrace(): void
+    public function testFailedQueueMessagesAreIgnoredByDefault(): void
     {
-        // Regression: previous formula effectively required age > 2 * grace.
-        $result = $this->collect(
-            connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-20 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
-            ],
-            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
-        );
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 2 HOUR', 'async_failed');
 
-        static::assertSame(SettingsResult::WARNING, $result->state);
-    }
-
-    public function testFailedQueuesAreExcludedByDefault(): void
-    {
-        $query = $this->createQueryBuilderMock(false);
-        $query->expects(static::once())
-            ->method('andWhere')
-            ->with('queue_name NOT LIKE :failedPattern')
-            ->willReturnSelf();
-        $query->expects(static::once())
-            ->method('setParameter')
-            ->with('failedPattern', '%failed%')
-            ->willReturnSelf();
-
-        $result = $this->collectWith(
-            connection: $this->connectionReturning($query),
-            config: [],
-        );
+        $result = $this->collectQueueResult();
 
         static::assertSame(SettingsResult::INFO, $result->state);
     }
 
-    public function testFailedQueuesCanBeIncluded(): void
+    public function testFailedQueueMessagesAreCountedWhenExclusionDisabled(): void
     {
-        $query = $this->createQueryBuilderMock([
-            'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-            'queue_name' => 'async_failed',
-        ]);
-        $query->expects(static::never())->method('andWhere');
+        $this->configService->set('FroshTools.config.monitorExcludeFailedQueues', false);
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 2 HOUR', 'async_failed');
 
-        $result = $this->collectWith(
-            connection: $this->connectionReturning($query),
-            config: ['FroshTools.config.monitorExcludeFailedQueues' => false],
-        );
+        $result = $this->collectQueueResult();
 
         static::assertSame(SettingsResult::WARNING, $result->state);
         static::assertStringContainsString('async_failed', $result->current);
     }
 
-    public function testAllowlistRestrictsMonitoredQueues(): void
+    public function testAllowlistIgnoresQueuesOutsideTheList(): void
     {
-        $query = $this->createQueryBuilderMock([
-            'available_at' => (new \DateTimeImmutable('-5 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-            'queue_name' => 'async',
-        ]);
+        $this->configService->set('FroshTools.config.monitorQueues', 'async');
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 2 HOUR', 'low_priority');
 
-        $andWhere = [];
-        $query->expects(static::exactly(2))
-            ->method('andWhere')
-            ->willReturnCallback(static function (string $predicate) use ($query, &$andWhere): QueryBuilder {
-                $andWhere[] = $predicate;
+        $result = $this->collectQueueResult();
 
-                return $query;
-            });
-
-        $parameters = [];
-        $query->expects(static::exactly(2))
-            ->method('setParameter')
-            ->willReturnCallback(static function (string $name, mixed $value, mixed $type = null) use ($query, &$parameters): QueryBuilder {
-                $parameters[$name] = ['value' => $value, 'type' => $type];
-
-                return $query;
-            });
-
-        $result = $this->collectWith(
-            connection: $this->connectionReturning($query),
-            config: [
-                'FroshTools.config.monitorQueues' => 'async, low_priority',
-                'FroshTools.config.monitorQueueGraceTime' => 15,
-            ],
-        );
-
-        static::assertContains('queue_name NOT LIKE :failedPattern', $andWhere);
-        static::assertContains('queue_name IN (:queues)', $andWhere);
-        static::assertSame('%failed%', $parameters['failedPattern']['value']);
-        static::assertSame(['async', 'low_priority'], $parameters['queues']['value']);
-        static::assertSame(ArrayParameterType::STRING, $parameters['queues']['type']);
-        static::assertSame(SettingsResult::GREEN, $result->state);
+        static::assertSame(SettingsResult::INFO, $result->state);
     }
 
-    public function testPerQueueGraceTimeOverridesDefault(): void
+    public function testAllowlistMonitorsListedQueue(): void
     {
-        $result = $this->collect(
-            connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-30 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'low_priority',
-            ],
-            config: [
-                'FroshTools.config.monitorQueueGraceTime' => 15,
-                'FroshTools.config.monitorQueueGraceTimes' => 'low_priority:60, async:10',
-            ],
-        );
+        $this->configService->set('FroshTools.config.monitorQueues', 'async, low_priority');
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 2 HOUR', 'async');
 
-        // 30 mins old with 60 min grace for low_priority → OK
-        static::assertSame(SettingsResult::GREEN, $result->state);
-        static::assertSame('max 60 mins', $result->recommended);
-    }
-
-    public function testPerQueueGraceTimeCanTightenDefault(): void
-    {
-        $result = $this->collect(
-            connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-12 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
-            ],
-            config: [
-                'FroshTools.config.monitorQueueGraceTime' => 15,
-                'FroshTools.config.monitorQueueGraceTimes' => 'async:10',
-            ],
-        );
+        $result = $this->collectQueueResult();
 
         static::assertSame(SettingsResult::WARNING, $result->state);
-        static::assertSame('max 10 mins', $result->recommended);
+        static::assertStringContainsString('async', $result->current);
     }
 
-    /**
-     * @param array{available_at: string, queue_name: string}|false $connectionRows
-     * @param array<string, mixed> $config
-     */
-    private function collect(array|false $connectionRows, array $config): SettingsResult
+    public function testPerQueueGraceTimeIsApplied(): void
     {
-        return $this->collectWith(
-            connection: $this->connectionReturning($this->createQueryBuilderMock($connectionRows)),
-            config: $config,
+        $this->configService->set('FroshTools.config.monitorQueueGraceTime', 15);
+        $this->configService->set('FroshTools.config.monitorQueueGraceTimes', 'low_priority:120');
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 30 MINUTE', 'low_priority');
+
+        $result = $this->collectQueueResult();
+
+        static::assertSame(SettingsResult::GREEN, $result->state);
+        static::assertSame('max 120 mins', $result->recommended);
+    }
+
+    private function insertMessage(string $availableAt, string $queueName = 'default'): void
+    {
+        $this->connection->executeStatement(
+            \sprintf(
+                "INSERT INTO messenger_messages (body, headers, queue_name, created_at, available_at) VALUES ('a:0:{}', '[]', %s, UTC_TIMESTAMP(), %s)",
+                $this->connection->quote($queueName),
+                $availableAt,
+            ),
         );
     }
 
-    /**
-     * @param array<string, mixed> $config
-     */
-    private function collectWith(Connection $connection, array $config): SettingsResult
+    private function collectQueueResult(): SettingsResult
     {
-        $configService = $this->createMock(SystemConfigService::class);
-        $configService->method('getInt')->willReturnCallback(
-            static fn (string $key): int => (int) ($config[$key] ?? 0),
-        );
-        $configService->method('getString')->willReturnCallback(
-            static fn (string $key): string => (string) ($config[$key] ?? ''),
-        );
-        $configService->method('get')->willReturnCallback(
-            static fn (string $key): mixed => $config[$key] ?? null,
-        );
-
         $collection = new HealthCollection();
-        (new QueueChecker($connection, $configService))->collect($collection);
+        $this->checker->collect($collection);
 
         foreach ($collection->getElements() as $element) {
             if ($element->id === 'queue') {
@@ -223,29 +140,11 @@ class QueueCheckerTest extends TestCase
         static::fail('HealthCollection does not contain a result with id "queue"');
     }
 
-    /**
-     * @param array{available_at: string, queue_name: string}|false $row
-     */
-    private function createQueryBuilderMock(array|false $row): QueryBuilder&MockObject
+    private function resetMonitorConfig(): void
     {
-        $query = $this->createMock(QueryBuilder::class);
-        $query->method('select')->willReturnSelf();
-        $query->method('from')->willReturnSelf();
-        $query->method('where')->willReturnSelf();
-        $query->method('andWhere')->willReturnSelf();
-        $query->method('orderBy')->willReturnSelf();
-        $query->method('setMaxResults')->willReturnSelf();
-        $query->method('setParameter')->willReturnSelf();
-        $query->method('fetchAssociative')->willReturn($row);
-
-        return $query;
-    }
-
-    private function connectionReturning(QueryBuilder $query): Connection&MockObject
-    {
-        $connection = $this->createMock(Connection::class);
-        $connection->method('createQueryBuilder')->willReturn($query);
-
-        return $connection;
+        $this->configService->delete('FroshTools.config.monitorExcludeFailedQueues');
+        $this->configService->delete('FroshTools.config.monitorQueues');
+        $this->configService->delete('FroshTools.config.monitorQueueGraceTimes');
+        $this->configService->set('FroshTools.config.monitorQueueGraceTime', 15);
     }
 }

--- a/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
@@ -115,6 +115,21 @@ class QueueCheckerTest extends IntegrationTestCase
         static::assertSame('max 120 mins', $result->recommended);
     }
 
+    public function testShorterGraceQueueIsNotMaskedByOlderLooserQueue(): void
+    {
+        $this->configService->set('FroshTools.config.monitorQueueGraceTime', 15);
+        $this->configService->set('FroshTools.config.monitorQueueGraceTimes', 'async:10, low_priority:120');
+        // Older message on a loose queue must not hide a newer overdue tight queue.
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 90 MINUTE', 'low_priority');
+        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 20 MINUTE', 'async');
+
+        $result = $this->collectQueueResult();
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertStringContainsString('async', $result->current);
+        static::assertSame('max 10 mins', $result->recommended);
+    }
+
     private function insertMessage(string $availableAt, string $queueName = 'default'): void
     {
         $this->connection->executeStatement(

--- a/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
@@ -8,61 +8,202 @@ use Doctrine\DBAL\Connection;
 use Frosh\Tools\Components\Health\Checker\HealthChecker\QueueChecker;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
-use Frosh\Tools\Tests\IntegrationTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 #[CoversClass(QueueChecker::class)]
-class QueueCheckerTest extends IntegrationTestCase
+class QueueCheckerTest extends TestCase
 {
-    private QueueChecker $checker;
-
-    private Connection $connection;
-
-    protected function setUp(): void
-    {
-        $this->checker = static::getContainer()->get(QueueChecker::class);
-        $this->connection = static::getContainer()->get(Connection::class);
-
-        $this->connection->executeStatement('DELETE FROM messenger_messages');
-    }
-
     public function testEmptyQueueResultsInInfoState(): void
     {
-        $result = $this->collectQueueResult();
+        $result = $this->collect(
+            connectionRows: false,
+            config: [],
+        );
 
         static::assertSame(SettingsResult::INFO, $result->state);
+        static::assertSame('0 mins', $result->current);
     }
 
     public function testOldMessageResultsInWarningState(): void
     {
-        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 2 HOUR');
-
-        $result = $this->collectQueueResult();
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
+            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
+        );
 
         static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertStringContainsString('async', $result->current);
     }
 
     public function testRecentMessageWithinGracePeriodResultsInOkState(): void
     {
-        $this->insertMessage('UTC_TIMESTAMP() - INTERVAL 1 MINUTE');
-
-        $result = $this->collectQueueResult();
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-1 minute', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
+            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
+        );
 
         static::assertSame(SettingsResult::GREEN, $result->state);
     }
 
-    private function insertMessage(string $availableAt): void
+    public function testMessageJustOverGraceIsWarningNotDoubleGrace(): void
     {
-        $this->connection->executeStatement(\sprintf(
-            "INSERT INTO messenger_messages (body, headers, queue_name, created_at, available_at) VALUES ('a:0:{}', '[]', 'default', UTC_TIMESTAMP(), %s)",
-            $availableAt,
-        ));
+        // Regression: previous formula effectively required age > 2 * grace.
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-20 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
+            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
+        );
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
     }
 
-    private function collectQueueResult(): SettingsResult
+    public function testFailedQueuesAreExcludedByDefault(): void
     {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(static::once())
+            ->method('fetchAssociative')
+            ->with(
+                static::callback(static function (string $sql): bool {
+                    return \str_contains($sql, 'NOT LIKE') && \str_contains($sql, 'queue_name');
+                }),
+                static::callback(static function (array $params): bool {
+                    return $params === ['%failed%'];
+                }),
+            )
+            ->willReturn(false);
+
+        $result = $this->collectWith(connection: $connection, config: []);
+
+        static::assertSame(SettingsResult::INFO, $result->state);
+    }
+
+    public function testFailedQueuesCanBeIncluded(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(static::once())
+            ->method('fetchAssociative')
+            ->with(
+                static::callback(static function (string $sql): bool {
+                    return !\str_contains($sql, 'NOT LIKE');
+                }),
+                static::equalTo([]),
+            )
+            ->willReturn([
+                'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async_failed',
+            ]);
+
+        $result = $this->collectWith(
+            connection: $connection,
+            config: ['FroshTools.config.monitorExcludeFailedQueues' => false],
+        );
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertStringContainsString('async_failed', $result->current);
+    }
+
+    public function testAllowlistRestrictsMonitoredQueues(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(static::once())
+            ->method('fetchAssociative')
+            ->with(
+                static::callback(static function (string $sql): bool {
+                    return \str_contains($sql, 'IN (');
+                }),
+                static::equalTo(['%failed%', 'async', 'low_priority']),
+            )
+            ->willReturn([
+                'available_at' => (new \DateTimeImmutable('-5 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ]);
+
+        $result = $this->collectWith(
+            connection: $connection,
+            config: [
+                'FroshTools.config.monitorQueues' => 'async, low_priority',
+                'FroshTools.config.monitorQueueGraceTime' => 15,
+            ],
+        );
+
+        static::assertSame(SettingsResult::GREEN, $result->state);
+    }
+
+    public function testPerQueueGraceTimeOverridesDefault(): void
+    {
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-30 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'low_priority',
+            ],
+            config: [
+                'FroshTools.config.monitorQueueGraceTime' => 15,
+                'FroshTools.config.monitorQueueGraceTimes' => 'low_priority:60, async:10',
+            ],
+        );
+
+        // 30 mins old with 60 min grace for low_priority → OK
+        static::assertSame(SettingsResult::GREEN, $result->state);
+        static::assertSame('max 60 mins', $result->recommended);
+    }
+
+    public function testPerQueueGraceTimeCanTightenDefault(): void
+    {
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-12 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
+            config: [
+                'FroshTools.config.monitorQueueGraceTime' => 15,
+                'FroshTools.config.monitorQueueGraceTimes' => 'async:10',
+            ],
+        );
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertSame('max 10 mins', $result->recommended);
+    }
+
+    /**
+     * @param array{available_at: string, queue_name: string}|false $connectionRows
+     * @param array<string, mixed> $config
+     */
+    private function collect(array|false $connectionRows, array $config): SettingsResult
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchAssociative')->willReturn($connectionRows);
+
+        return $this->collectWith($connection, $config);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function collectWith(Connection $connection, array $config): SettingsResult
+    {
+        $configService = $this->createMock(SystemConfigService::class);
+        $configService->method('getInt')->willReturnCallback(
+            static fn (string $key): int => (int) ($config[$key] ?? 0),
+        );
+        $configService->method('getString')->willReturnCallback(
+            static fn (string $key): string => (string) ($config[$key] ?? ''),
+        );
+        $configService->method('get')->willReturnCallback(
+            static fn (string $key): mixed => $config[$key] ?? null,
+        );
+
         $collection = new HealthCollection();
-        $this->checker->collect($collection);
+        (new QueueChecker($connection, $configService))->collect($collection);
 
         foreach ($collection->getElements() as $element) {
             if ($element->id === 'queue') {

--- a/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/QueueCheckerTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Tests\Components\Health\Checker\HealthChecker;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Frosh\Tools\Components\Health\Checker\HealthChecker\QueueChecker;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
@@ -69,42 +72,34 @@ class QueueCheckerTest extends TestCase
 
     public function testFailedQueuesAreExcludedByDefault(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $connection->expects(static::once())
-            ->method('fetchAssociative')
-            ->with(
-                static::callback(static function (string $sql): bool {
-                    return \str_contains($sql, 'NOT LIKE') && \str_contains($sql, 'queue_name');
-                }),
-                static::callback(static function (array $params): bool {
-                    return $params === ['%failed%'];
-                }),
-            )
-            ->willReturn(false);
+        $query = $this->createQueryBuilderMock(false);
+        $query->expects(static::once())
+            ->method('andWhere')
+            ->with('queue_name NOT LIKE :failedPattern')
+            ->willReturnSelf();
+        $query->expects(static::once())
+            ->method('setParameter')
+            ->with('failedPattern', '%failed%')
+            ->willReturnSelf();
 
-        $result = $this->collectWith(connection: $connection, config: []);
+        $result = $this->collectWith(
+            connection: $this->connectionReturning($query),
+            config: [],
+        );
 
         static::assertSame(SettingsResult::INFO, $result->state);
     }
 
     public function testFailedQueuesCanBeIncluded(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $connection->expects(static::once())
-            ->method('fetchAssociative')
-            ->with(
-                static::callback(static function (string $sql): bool {
-                    return !\str_contains($sql, 'NOT LIKE');
-                }),
-                static::equalTo([]),
-            )
-            ->willReturn([
-                'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async_failed',
-            ]);
+        $query = $this->createQueryBuilderMock([
+            'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+            'queue_name' => 'async_failed',
+        ]);
+        $query->expects(static::never())->method('andWhere');
 
         $result = $this->collectWith(
-            connection: $connection,
+            connection: $this->connectionReturning($query),
             config: ['FroshTools.config.monitorExcludeFailedQueues' => false],
         );
 
@@ -114,28 +109,42 @@ class QueueCheckerTest extends TestCase
 
     public function testAllowlistRestrictsMonitoredQueues(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $connection->expects(static::once())
-            ->method('fetchAssociative')
-            ->with(
-                static::callback(static function (string $sql): bool {
-                    return \str_contains($sql, 'IN (');
-                }),
-                static::equalTo(['%failed%', 'async', 'low_priority']),
-            )
-            ->willReturn([
-                'available_at' => (new \DateTimeImmutable('-5 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
-            ]);
+        $query = $this->createQueryBuilderMock([
+            'available_at' => (new \DateTimeImmutable('-5 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+            'queue_name' => 'async',
+        ]);
+
+        $andWhere = [];
+        $query->expects(static::exactly(2))
+            ->method('andWhere')
+            ->willReturnCallback(static function (string $predicate) use ($query, &$andWhere): QueryBuilder {
+                $andWhere[] = $predicate;
+
+                return $query;
+            });
+
+        $parameters = [];
+        $query->expects(static::exactly(2))
+            ->method('setParameter')
+            ->willReturnCallback(static function (string $name, mixed $value, mixed $type = null) use ($query, &$parameters): QueryBuilder {
+                $parameters[$name] = ['value' => $value, 'type' => $type];
+
+                return $query;
+            });
 
         $result = $this->collectWith(
-            connection: $connection,
+            connection: $this->connectionReturning($query),
             config: [
                 'FroshTools.config.monitorQueues' => 'async, low_priority',
                 'FroshTools.config.monitorQueueGraceTime' => 15,
             ],
         );
 
+        static::assertContains('queue_name NOT LIKE :failedPattern', $andWhere);
+        static::assertContains('queue_name IN (:queues)', $andWhere);
+        static::assertSame('%failed%', $parameters['failedPattern']['value']);
+        static::assertSame(['async', 'low_priority'], $parameters['queues']['value']);
+        static::assertSame(ArrayParameterType::STRING, $parameters['queues']['type']);
         static::assertSame(SettingsResult::GREEN, $result->state);
     }
 
@@ -180,10 +189,10 @@ class QueueCheckerTest extends TestCase
      */
     private function collect(array|false $connectionRows, array $config): SettingsResult
     {
-        $connection = $this->createMock(Connection::class);
-        $connection->method('fetchAssociative')->willReturn($connectionRows);
-
-        return $this->collectWith($connection, $config);
+        return $this->collectWith(
+            connection: $this->connectionReturning($this->createQueryBuilderMock($connectionRows)),
+            config: $config,
+        );
     }
 
     /**
@@ -212,5 +221,31 @@ class QueueCheckerTest extends TestCase
         }
 
         static::fail('HealthCollection does not contain a result with id "queue"');
+    }
+
+    /**
+     * @param array{available_at: string, queue_name: string}|false $row
+     */
+    private function createQueryBuilderMock(array|false $row): QueryBuilder&MockObject
+    {
+        $query = $this->createMock(QueryBuilder::class);
+        $query->method('select')->willReturnSelf();
+        $query->method('from')->willReturnSelf();
+        $query->method('where')->willReturnSelf();
+        $query->method('andWhere')->willReturnSelf();
+        $query->method('orderBy')->willReturnSelf();
+        $query->method('setMaxResults')->willReturnSelf();
+        $query->method('setParameter')->willReturnSelf();
+        $query->method('fetchAssociative')->willReturn($row);
+
+        return $query;
+    }
+
+    private function connectionReturning(QueryBuilder $query): Connection&MockObject
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createQueryBuilder')->willReturn($query);
+
+        return $connection;
     }
 }

--- a/tests/Components/Health/Checker/HealthChecker/QueueCheckerUnitTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/QueueCheckerUnitTest.php
@@ -25,7 +25,7 @@ class QueueCheckerUnitTest extends TestCase
     public function testEmptyQueueResultsInInfoState(): void
     {
         $result = $this->collect(
-            connectionRows: false,
+            connectionRows: [],
             config: [],
         );
 
@@ -37,8 +37,10 @@ class QueueCheckerUnitTest extends TestCase
     {
         $result = $this->collect(
             connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
+                [
+                    'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                    'queue_name' => 'async',
+                ],
             ],
             config: ['FroshTools.config.monitorQueueGraceTime' => 15],
         );
@@ -51,8 +53,10 @@ class QueueCheckerUnitTest extends TestCase
     {
         $result = $this->collect(
             connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-1 minute', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
+                [
+                    'available_at' => (new \DateTimeImmutable('-1 minute', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                    'queue_name' => 'async',
+                ],
             ],
             config: ['FroshTools.config.monitorQueueGraceTime' => 15],
         );
@@ -65,8 +69,10 @@ class QueueCheckerUnitTest extends TestCase
         // Regression: previous formula effectively required age > 2 * grace.
         $result = $this->collect(
             connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-20 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
+                [
+                    'available_at' => (new \DateTimeImmutable('-20 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                    'queue_name' => 'async',
+                ],
             ],
             config: ['FroshTools.config.monitorQueueGraceTime' => 15],
         );
@@ -76,7 +82,7 @@ class QueueCheckerUnitTest extends TestCase
 
     public function testFailedQueuesAreExcludedByDefault(): void
     {
-        $query = $this->createQueryBuilderMock(false);
+        $query = $this->createQueryBuilderMock([]);
         $query->expects(static::once())
             ->method('andWhere')
             ->with('queue_name NOT LIKE :failedPattern')
@@ -97,8 +103,10 @@ class QueueCheckerUnitTest extends TestCase
     public function testFailedQueuesCanBeIncluded(): void
     {
         $query = $this->createQueryBuilderMock([
-            'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-            'queue_name' => 'async_failed',
+            [
+                'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async_failed',
+            ],
         ]);
         $query->expects(static::never())->method('andWhere');
 
@@ -114,8 +122,10 @@ class QueueCheckerUnitTest extends TestCase
     public function testAllowlistRestrictsMonitoredQueues(): void
     {
         $query = $this->createQueryBuilderMock([
-            'available_at' => (new \DateTimeImmutable('-5 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-            'queue_name' => 'async',
+            [
+                'available_at' => (new \DateTimeImmutable('-5 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
         ]);
 
         $andWhere = [];
@@ -156,8 +166,10 @@ class QueueCheckerUnitTest extends TestCase
     {
         $result = $this->collect(
             connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-30 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'low_priority',
+                [
+                    'available_at' => (new \DateTimeImmutable('-30 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                    'queue_name' => 'low_priority',
+                ],
             ],
             config: [
                 'FroshTools.config.monitorQueueGraceTime' => 15,
@@ -174,8 +186,10 @@ class QueueCheckerUnitTest extends TestCase
     {
         $result = $this->collect(
             connectionRows: [
-                'available_at' => (new \DateTimeImmutable('-12 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
-                'queue_name' => 'async',
+                [
+                    'available_at' => (new \DateTimeImmutable('-12 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                    'queue_name' => 'async',
+                ],
             ],
             config: [
                 'FroshTools.config.monitorQueueGraceTime' => 15,
@@ -187,11 +201,37 @@ class QueueCheckerUnitTest extends TestCase
         static::assertSame('max 10 mins', $result->recommended);
     }
 
+    public function testShorterGraceQueueIsNotMaskedByOlderLooserQueue(): void
+    {
+        // Greptile P1: oldest global message was on low_priority (grace 120), which masked
+        // a newer async message that already exceeded async's shorter grace (10).
+        $result = $this->collect(
+            connectionRows: [
+                [
+                    'available_at' => (new \DateTimeImmutable('-90 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                    'queue_name' => 'low_priority',
+                ],
+                [
+                    'available_at' => (new \DateTimeImmutable('-20 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                    'queue_name' => 'async',
+                ],
+            ],
+            config: [
+                'FroshTools.config.monitorQueueGraceTime' => 15,
+                'FroshTools.config.monitorQueueGraceTimes' => 'async:10, low_priority:120',
+            ],
+        );
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertStringContainsString('async', $result->current);
+        static::assertSame('max 10 mins', $result->recommended);
+    }
+
     /**
-     * @param array{available_at: string, queue_name: string}|false $connectionRows
+     * @param list<array{available_at: string, queue_name: string}> $connectionRows
      * @param array<string, mixed> $config
      */
-    private function collect(array|false $connectionRows, array $config): SettingsResult
+    private function collect(array $connectionRows, array $config): SettingsResult
     {
         return $this->collectWith(
             connection: $this->connectionReturning($this->createQueryBuilderMock($connectionRows)),
@@ -228,19 +268,20 @@ class QueueCheckerUnitTest extends TestCase
     }
 
     /**
-     * @param array{available_at: string, queue_name: string}|false $row
+     * @param list<array{available_at: string, queue_name: string}> $rows
      */
-    private function createQueryBuilderMock(array|false $row): QueryBuilder&MockObject
+    private function createQueryBuilderMock(array $rows): QueryBuilder&MockObject
     {
         $query = $this->createMock(QueryBuilder::class);
         $query->method('select')->willReturnSelf();
         $query->method('from')->willReturnSelf();
         $query->method('where')->willReturnSelf();
         $query->method('andWhere')->willReturnSelf();
+        $query->method('groupBy')->willReturnSelf();
         $query->method('orderBy')->willReturnSelf();
         $query->method('setMaxResults')->willReturnSelf();
         $query->method('setParameter')->willReturnSelf();
-        $query->method('fetchAssociative')->willReturn($row);
+        $query->method('fetchAllAssociative')->willReturn($rows);
 
         return $query;
     }

--- a/tests/Components/Health/Checker/HealthChecker/QueueCheckerUnitTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/QueueCheckerUnitTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\Health\Checker\HealthChecker;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Frosh\Tools\Components\Health\Checker\HealthChecker\QueueChecker;
+use Frosh\Tools\Components\Health\HealthCollection;
+use Frosh\Tools\Components\Health\SettingsResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+/**
+ * Fast mock-based coverage for QueueChecker config/age edge cases.
+ * Real DB/QueryBuilder behaviour is covered by QueueCheckerTest (integration).
+ */
+#[CoversClass(QueueChecker::class)]
+class QueueCheckerUnitTest extends TestCase
+{
+    public function testEmptyQueueResultsInInfoState(): void
+    {
+        $result = $this->collect(
+            connectionRows: false,
+            config: [],
+        );
+
+        static::assertSame(SettingsResult::INFO, $result->state);
+        static::assertSame('0 mins', $result->current);
+    }
+
+    public function testOldMessageResultsInWarningState(): void
+    {
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
+            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
+        );
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertStringContainsString('async', $result->current);
+    }
+
+    public function testRecentMessageWithinGracePeriodResultsInOkState(): void
+    {
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-1 minute', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
+            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
+        );
+
+        static::assertSame(SettingsResult::GREEN, $result->state);
+    }
+
+    public function testMessageJustOverGraceIsWarningNotDoubleGrace(): void
+    {
+        // Regression: previous formula effectively required age > 2 * grace.
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-20 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
+            config: ['FroshTools.config.monitorQueueGraceTime' => 15],
+        );
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+    }
+
+    public function testFailedQueuesAreExcludedByDefault(): void
+    {
+        $query = $this->createQueryBuilderMock(false);
+        $query->expects(static::once())
+            ->method('andWhere')
+            ->with('queue_name NOT LIKE :failedPattern')
+            ->willReturnSelf();
+        $query->expects(static::once())
+            ->method('setParameter')
+            ->with('failedPattern', '%failed%')
+            ->willReturnSelf();
+
+        $result = $this->collectWith(
+            connection: $this->connectionReturning($query),
+            config: [],
+        );
+
+        static::assertSame(SettingsResult::INFO, $result->state);
+    }
+
+    public function testFailedQueuesCanBeIncluded(): void
+    {
+        $query = $this->createQueryBuilderMock([
+            'available_at' => (new \DateTimeImmutable('-2 hours', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+            'queue_name' => 'async_failed',
+        ]);
+        $query->expects(static::never())->method('andWhere');
+
+        $result = $this->collectWith(
+            connection: $this->connectionReturning($query),
+            config: ['FroshTools.config.monitorExcludeFailedQueues' => false],
+        );
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertStringContainsString('async_failed', $result->current);
+    }
+
+    public function testAllowlistRestrictsMonitoredQueues(): void
+    {
+        $query = $this->createQueryBuilderMock([
+            'available_at' => (new \DateTimeImmutable('-5 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+            'queue_name' => 'async',
+        ]);
+
+        $andWhere = [];
+        $query->expects(static::exactly(2))
+            ->method('andWhere')
+            ->willReturnCallback(static function (string $predicate) use ($query, &$andWhere): QueryBuilder {
+                $andWhere[] = $predicate;
+
+                return $query;
+            });
+
+        $parameters = [];
+        $query->expects(static::exactly(2))
+            ->method('setParameter')
+            ->willReturnCallback(static function (string $name, mixed $value, mixed $type = null) use ($query, &$parameters): QueryBuilder {
+                $parameters[$name] = ['value' => $value, 'type' => $type];
+
+                return $query;
+            });
+
+        $result = $this->collectWith(
+            connection: $this->connectionReturning($query),
+            config: [
+                'FroshTools.config.monitorQueues' => 'async, low_priority',
+                'FroshTools.config.monitorQueueGraceTime' => 15,
+            ],
+        );
+
+        static::assertContains('queue_name NOT LIKE :failedPattern', $andWhere);
+        static::assertContains('queue_name IN (:queues)', $andWhere);
+        static::assertSame('%failed%', $parameters['failedPattern']['value']);
+        static::assertSame(['async', 'low_priority'], $parameters['queues']['value']);
+        static::assertSame(ArrayParameterType::STRING, $parameters['queues']['type']);
+        static::assertSame(SettingsResult::GREEN, $result->state);
+    }
+
+    public function testPerQueueGraceTimeOverridesDefault(): void
+    {
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-30 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'low_priority',
+            ],
+            config: [
+                'FroshTools.config.monitorQueueGraceTime' => 15,
+                'FroshTools.config.monitorQueueGraceTimes' => 'low_priority:60, async:10',
+            ],
+        );
+
+        // 30 mins old with 60 min grace for low_priority → OK
+        static::assertSame(SettingsResult::GREEN, $result->state);
+        static::assertSame('max 60 mins', $result->recommended);
+    }
+
+    public function testPerQueueGraceTimeCanTightenDefault(): void
+    {
+        $result = $this->collect(
+            connectionRows: [
+                'available_at' => (new \DateTimeImmutable('-12 minutes', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s'),
+                'queue_name' => 'async',
+            ],
+            config: [
+                'FroshTools.config.monitorQueueGraceTime' => 15,
+                'FroshTools.config.monitorQueueGraceTimes' => 'async:10',
+            ],
+        );
+
+        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertSame('max 10 mins', $result->recommended);
+    }
+
+    /**
+     * @param array{available_at: string, queue_name: string}|false $connectionRows
+     * @param array<string, mixed> $config
+     */
+    private function collect(array|false $connectionRows, array $config): SettingsResult
+    {
+        return $this->collectWith(
+            connection: $this->connectionReturning($this->createQueryBuilderMock($connectionRows)),
+            config: $config,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function collectWith(Connection $connection, array $config): SettingsResult
+    {
+        $configService = $this->createMock(SystemConfigService::class);
+        $configService->method('getInt')->willReturnCallback(
+            static fn (string $key): int => (int) ($config[$key] ?? 0),
+        );
+        $configService->method('getString')->willReturnCallback(
+            static fn (string $key): string => (string) ($config[$key] ?? ''),
+        );
+        $configService->method('get')->willReturnCallback(
+            static fn (string $key): mixed => $config[$key] ?? null,
+        );
+
+        $collection = new HealthCollection();
+        (new QueueChecker($connection, $configService))->collect($collection);
+
+        foreach ($collection->getElements() as $element) {
+            if ($element->id === 'queue') {
+                return $element;
+            }
+        }
+
+        static::fail('HealthCollection does not contain a result with id "queue"');
+    }
+
+    /**
+     * @param array{available_at: string, queue_name: string}|false $row
+     */
+    private function createQueryBuilderMock(array|false $row): QueryBuilder&MockObject
+    {
+        $query = $this->createMock(QueryBuilder::class);
+        $query->method('select')->willReturnSelf();
+        $query->method('from')->willReturnSelf();
+        $query->method('where')->willReturnSelf();
+        $query->method('andWhere')->willReturnSelf();
+        $query->method('orderBy')->willReturnSelf();
+        $query->method('setMaxResults')->willReturnSelf();
+        $query->method('setParameter')->willReturnSelf();
+        $query->method('fetchAssociative')->willReturn($row);
+
+        return $query;
+    }
+
+    private function connectionReturning(QueryBuilder $query): Connection&MockObject
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('createQueryBuilder')->willReturn($query);
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
## Summary

Implements [#269](https://github.com/FriendsOfShopware/FroshTools/issues/269).

Failed messenger queues (e.g. `async_failed`) that are drained manually were counted by `QueueChecker`, which led to false positives in **System Status** and `frosh:monitor`.

### Changes
| Setting | Default | Purpose |
|---|---|---|
| **Exclude failed queues** | `true` | Skip `queue_name LIKE '%failed%'` |
| **Queues to monitor** | empty (all) | Optional comma-separated allowlist |
| **Per-queue grace times** | empty | `async:15, low_priority:60` overrides |
| **Default queue grace time** | `15` | Unchanged key, clearer label |

Also fixes age math: the previous formula effectively required `age > 2 × grace` before warning. It now uses the real pending age in minutes.

Status `current` now includes the queue name, e.g. `42 mins (async)`.

### Config UI
Extension config → **Monitoring** card (DE labels included).

### Tests
```
OK (9 tests, 23 assertions)
```
Unit tests with mocked `Connection` / `SystemConfigService` (no kernel).

## Test plan
- [x] Unit tests green
- [ ] CI on PR
- [ ] Manual: insert old row into `async_failed` → no warning with default config; warning when “Exclude failed queues” is off