### PR TITLE
Add per-area ACL privileges for Frosh Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,13 @@ The Shopware version indicator is extended with a compact **health status** (suc
 
 - Shopware **6.6** or **6.7**
 - PHP version required by your Shopware minor
-- Admin ACL privilege `frosh_tools:read` (and webhook privileges where applicable)
+- Admin ACL privileges under **Settings → Users & permissions** (Viewer / Editor per area):
+  - **Frosh Tools** — system status, statistics, feature flags, state machines. Editor grants every Tools write privilege (and pulls in the other viewers).
+  - **Cache / Queue / Scheduled tasks / Search indices / Security / Fastly / Shopmon** — Viewer to open the tab, Editor for mutations (clear cache, retry/purge, run tasks, reindex, restore files, purge CDN, setup integration).
+  - **Logs** — Viewer only (production log contents).
+  - Webhook privileges remain a separate CRUD row.
+
+  Existing roles that only had `frosh_tools:read` keep the overview tabs; re-open the role and tick the area viewers/editors they should keep. Super-admin is unchanged.
 
 ---
 

--- a/src/Acl/FroshToolsPrivileges.php
+++ b/src/Acl/FroshToolsPrivileges.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Acl;
+
+/**
+ * Privilege strings used by API routes and the Administration ACL mapping.
+ *
+ * Area suffixes follow Shopware's entity convention (`:read` / `:update`) so
+ * roles can grant view access without also granting destructive actions.
+ */
+final class FroshToolsPrivileges
+{
+    public const READ = 'frosh_tools:read';
+
+    public const CACHE_READ = 'frosh_tools_cache:read';
+    public const CACHE_UPDATE = 'frosh_tools_cache:update';
+
+    public const QUEUE_READ = 'frosh_tools_queue:read';
+    public const QUEUE_UPDATE = 'frosh_tools_queue:update';
+
+    public const SCHEDULED_TASK_READ = 'frosh_tools_scheduled_task:read';
+    public const SCHEDULED_TASK_UPDATE = 'frosh_tools_scheduled_task:update';
+
+    public const ELASTICSEARCH_READ = 'frosh_tools_elasticsearch:read';
+    public const ELASTICSEARCH_UPDATE = 'frosh_tools_elasticsearch:update';
+
+    public const LOGS_READ = 'frosh_tools_logs:read';
+
+    public const SECURITY_READ = 'frosh_tools_security:read';
+    public const SECURITY_UPDATE = 'frosh_tools_security:update';
+
+    public const FASTLY_READ = 'frosh_tools_fastly:read';
+    public const FASTLY_UPDATE = 'frosh_tools_fastly:update';
+
+    public const SHOPMON_READ = 'frosh_tools_shopmon:read';
+    public const SHOPMON_UPDATE = 'frosh_tools_shopmon:update';
+
+    /**
+     * @return list<string>
+     */
+    public static function allRead(): array
+    {
+        return [
+            self::READ,
+            self::CACHE_READ,
+            self::QUEUE_READ,
+            self::SCHEDULED_TASK_READ,
+            self::ELASTICSEARCH_READ,
+            self::LOGS_READ,
+            self::SECURITY_READ,
+            self::FASTLY_READ,
+            self::SHOPMON_READ,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allUpdate(): array
+    {
+        return [
+            self::CACHE_UPDATE,
+            self::QUEUE_UPDATE,
+            self::SCHEDULED_TASK_UPDATE,
+            self::ELASTICSEARCH_UPDATE,
+            self::SECURITY_UPDATE,
+            self::FASTLY_UPDATE,
+            self::SHOPMON_UPDATE,
+        ];
+    }
+}

--- a/src/Controller/CacheController.php
+++ b/src/Controller/CacheController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\CacheHelper;
 use Frosh\Tools\Components\CacheRegistry;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -12,7 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::CACHE_READ]])]
 class CacheController extends AbstractController
 {
     public function __construct(
@@ -72,7 +73,7 @@ class CacheController extends AbstractController
         return new JsonResponse($result);
     }
 
-    #[Route(path: '/cache/{folder}', name: 'api.frosh.tools.cache.clear', methods: ['DELETE'])]
+    #[Route(path: '/cache/{folder}', name: 'api.frosh.tools.cache.clear', defaults: ['_acl' => [FroshToolsPrivileges::CACHE_UPDATE]], methods: ['DELETE'])]
     public function clearCache(string $folder): JsonResponse
     {
         if ($this->cacheRegistry->has($folder)) {
@@ -84,7 +85,7 @@ class CacheController extends AbstractController
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/cache_clear_opcache', name: 'api.frosh.tools.cache.clear_opcache', methods: ['DELETE'])]
+    #[Route(path: '/cache_clear_opcache', name: 'api.frosh.tools.cache.clear_opcache', defaults: ['_acl' => [FroshToolsPrivileges::CACHE_UPDATE]], methods: ['DELETE'])]
     public function clearOpCache(): JsonResponse
     {
         if (\function_exists('opcache_reset')) {

--- a/src/Controller/ComposerAuditController.php
+++ b/src/Controller/ComposerAuditController.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\ComposerAudit\ComposerAuditService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::SECURITY_READ]])]
 class ComposerAuditController extends AbstractController
 {
     public function __construct(

--- a/src/Controller/ElasticsearchController.php
+++ b/src/Controller/ElasticsearchController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\Elasticsearch\ElasticsearchManager;
 use Frosh\Tools\Components\Exception\FroshToolsException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -12,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools/elasticsearch', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools/elasticsearch', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::ELASTICSEARCH_READ]])]
 class ElasticsearchController extends AbstractController
 {
     public function __construct(private readonly ElasticsearchManager $manager)
@@ -39,7 +40,7 @@ class ElasticsearchController extends AbstractController
         return new JsonResponse($this->manager->indices());
     }
 
-    #[Route(path: '/index/{indexName}', name: 'api.frosh.tools.elasticsearch.delete_index', methods: ['DELETE'])]
+    #[Route(path: '/index/{indexName}', name: 'api.frosh.tools.elasticsearch.delete_index', defaults: ['_acl' => [FroshToolsPrivileges::ELASTICSEARCH_UPDATE]], methods: ['DELETE'])]
     public function deleteIndex(string $indexName): Response
     {
         if (!$this->manager->isEnabled()) {
@@ -49,7 +50,7 @@ class ElasticsearchController extends AbstractController
         return new JsonResponse($this->manager->deleteIndex($indexName));
     }
 
-    #[Route(path: '/console/{path}', name: 'api.frosh.tools.elasticsearch.proxy', requirements: ['path' => '.*'])]
+    #[Route(path: '/console/{path}', name: 'api.frosh.tools.elasticsearch.proxy', requirements: ['path' => '.*'], defaults: ['_acl' => [FroshToolsPrivileges::ELASTICSEARCH_UPDATE]])]
     public function console(Request $request, string $path): Response
     {
         if (!$this->manager->isEnabled()) {
@@ -69,7 +70,7 @@ class ElasticsearchController extends AbstractController
         return new JsonResponse($data);
     }
 
-    #[Route(path: '/flush_all', name: 'api.frosh.tools.elasticsearch.flush', methods: ['POST'])]
+    #[Route(path: '/flush_all', name: 'api.frosh.tools.elasticsearch.flush', defaults: ['_acl' => [FroshToolsPrivileges::ELASTICSEARCH_UPDATE]], methods: ['POST'])]
     public function flushAll(): Response
     {
         $this->manager->flushAll();
@@ -77,7 +78,7 @@ class ElasticsearchController extends AbstractController
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/reindex', name: 'api.frosh.tools.elasticsearch.reindex', methods: ['POST'])]
+    #[Route(path: '/reindex', name: 'api.frosh.tools.elasticsearch.reindex', defaults: ['_acl' => [FroshToolsPrivileges::ELASTICSEARCH_UPDATE]], methods: ['POST'])]
     public function reindex(): Response
     {
         $this->manager->reindex();
@@ -85,7 +86,7 @@ class ElasticsearchController extends AbstractController
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/switch_alias', name: 'api.frosh.tools.elasticsearch.switch_alias', methods: ['POST'])]
+    #[Route(path: '/switch_alias', name: 'api.frosh.tools.elasticsearch.switch_alias', defaults: ['_acl' => [FroshToolsPrivileges::ELASTICSEARCH_UPDATE]], methods: ['POST'])]
     public function switchAlias(): Response
     {
         $this->manager->switchAlias();
@@ -113,7 +114,7 @@ class ElasticsearchController extends AbstractController
         return new JsonResponse($this->manager->getOrphanedIndices());
     }
 
-    #[Route(path: '/cleanup', name: 'api.frosh.tools.elasticsearch.cleanup', methods: ['POST'])]
+    #[Route(path: '/cleanup', name: 'api.frosh.tools.elasticsearch.cleanup', defaults: ['_acl' => [FroshToolsPrivileges::ELASTICSEARCH_UPDATE]], methods: ['POST'])]
     public function deleteUnusedIndices(): Response
     {
         if (!$this->manager->isEnabled()) {
@@ -123,7 +124,7 @@ class ElasticsearchController extends AbstractController
         return new JsonResponse($this->manager->deleteUnusedIndices());
     }
 
-    #[Route(path: '/cleanup_orphaned', name: 'api.frosh.tools.elasticsearch.cleanup_orphaned', methods: ['POST'])]
+    #[Route(path: '/cleanup_orphaned', name: 'api.frosh.tools.elasticsearch.cleanup_orphaned', defaults: ['_acl' => [FroshToolsPrivileges::ELASTICSEARCH_UPDATE]], methods: ['POST'])]
     public function deleteOrphanedIndices(Request $request): Response
     {
         if (!$this->manager->isEnabled()) {
@@ -157,7 +158,7 @@ class ElasticsearchController extends AbstractController
         return new JsonResponse($this->manager->deleteOrphanedIndices($indices));
     }
 
-    #[Route(path: '/reset', name: 'api.frosh.tools.elasticsearch.reset', methods: ['POST'])]
+    #[Route(path: '/reset', name: 'api.frosh.tools.elasticsearch.reset', defaults: ['_acl' => [FroshToolsPrivileges::ELASTICSEARCH_UPDATE]], methods: ['POST'])]
     public function reset(): Response
     {
         $this->manager->reset();

--- a/src/Controller/ExtensionFilesController.php
+++ b/src/Controller/ExtensionFilesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\ExtensionChecksum\ExtensionFileHashService;
 use Frosh\Tools\Components\ExtensionChecksum\Struct\ExtensionChecksumCheckResult;
 use Psr\Log\LoggerInterface;
@@ -17,7 +18,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AutoconfigureTag('monolog.logger', ['channel' => 'frosh-tools'])]
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::SECURITY_READ]])]
 class ExtensionFilesController extends AbstractController
 {
     /**

--- a/src/Controller/FastlyController.php
+++ b/src/Controller/FastlyController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -13,7 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-#[Route(path: '/api/_action/frosh-tools/fastly', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools/fastly', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::FASTLY_READ]])]
 class FastlyController extends AbstractController
 {
     public function __construct(
@@ -122,7 +123,7 @@ class FastlyController extends AbstractController
         return new JsonResponse($response->toArray());
     }
 
-    #[Route(path: '/purge', name: 'api.frosh.tools.fastly.purge', methods: ['POST'])]
+    #[Route(path: '/purge', name: 'api.frosh.tools.fastly.purge', defaults: ['_acl' => [FroshToolsPrivileges::FASTLY_UPDATE]], methods: ['POST'])]
     public function purge(Request $request): JsonResponse
     {
         if (!$this->reverseProxyGateway || !$this->isFastlyEnabled()) {
@@ -140,7 +141,7 @@ class FastlyController extends AbstractController
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/purge-all', name: 'api.frosh.tools.fastly.purge_all', methods: ['POST'])]
+    #[Route(path: '/purge-all', name: 'api.frosh.tools.fastly.purge_all', defaults: ['_acl' => [FroshToolsPrivileges::FASTLY_UPDATE]], methods: ['POST'])]
     public function purgeAll(): JsonResponse
     {
         if (!$this->reverseProxyGateway || !$this->isFastlyEnabled()) {

--- a/src/Controller/FeatureFlagController.php
+++ b/src/Controller/FeatureFlagController.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Shopware\Core\Framework\Feature;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::READ]])]
 class FeatureFlagController
 {
     #[Route(path: '/feature-flag/list', name: 'api.frosh.tools.feature-flag.list', methods: ['GET'])]

--- a/src/Controller/HealthController.php
+++ b/src/Controller/HealthController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\Health\Checker\CheckerInterface;
 use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\PerformanceCollection;
@@ -15,7 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::READ]])]
 class HealthController extends AbstractController
 {
     /**

--- a/src/Controller/LogController.php
+++ b/src/Controller/LogController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\LineReader;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -14,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::LOGS_READ]])]
 class LogController extends AbstractController
 {
     // https://regex101.com/r/bp4YYL/1

--- a/src/Controller/QueueController.php
+++ b/src/Controller/QueueController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Frosh\Tools\Controller;
 
 use Doctrine\DBAL\Connection;
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\Queue\QueueRegistry;
 use Frosh\Tools\Components\Queue\WorkerHeartbeatListener;
 use Psr\Cache\CacheItemPoolInterface;
@@ -19,7 +20,7 @@ use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::QUEUE_READ]])]
 class QueueController extends AbstractController
 {
     /**
@@ -63,7 +64,7 @@ class QueueController extends AbstractController
         return new JsonResponse($transports);
     }
 
-    #[Route(path: '/queue/transport/{name}/messages/{id}/retry', name: 'api.frosh.tools.queue.message.retry', requirements: ['id' => '.+'], defaults: ['_acl' => ['frosh_tools:update']], methods: ['POST'])]
+    #[Route(path: '/queue/transport/{name}/messages/{id}/retry', name: 'api.frosh.tools.queue.message.retry', requirements: ['id' => '.+'], defaults: ['_acl' => [FroshToolsPrivileges::QUEUE_UPDATE]], methods: ['POST'])]
     public function retryMessage(string $name, string $id): JsonResponse
     {
         $adapter = $this->queueRegistry->has($name) ? $this->queueRegistry->get($name) : null;
@@ -78,7 +79,7 @@ class QueueController extends AbstractController
         return $this->executeMessageAction(static fn () => $adapter->retryMessage($id));
     }
 
-    #[Route(path: '/queue/transport/{name}/messages/{id}', name: 'api.frosh.tools.queue.message.delete', requirements: ['id' => '.+'], defaults: ['_acl' => ['frosh_tools:update']], methods: ['DELETE'])]
+    #[Route(path: '/queue/transport/{name}/messages/{id}', name: 'api.frosh.tools.queue.message.delete', requirements: ['id' => '.+'], defaults: ['_acl' => [FroshToolsPrivileges::QUEUE_UPDATE]], methods: ['DELETE'])]
     public function deleteMessage(string $name, string $id): JsonResponse
     {
         $adapter = $this->queueRegistry->has($name) ? $this->queueRegistry->get($name) : null;
@@ -93,7 +94,7 @@ class QueueController extends AbstractController
         return $this->executeMessageAction(static fn () => $adapter->removeMessage($id));
     }
 
-    #[Route(path: '/queue/transport/{name}', name: 'api.frosh.tools.queue.transport.purge', defaults: ['_acl' => ['frosh_tools:update']], methods: ['DELETE'])]
+    #[Route(path: '/queue/transport/{name}', name: 'api.frosh.tools.queue.transport.purge', defaults: ['_acl' => [FroshToolsPrivileges::QUEUE_UPDATE]], methods: ['DELETE'])]
     public function purgeTransport(string $name): JsonResponse
     {
         $adapter = $this->queueRegistry->has($name) ? $this->queueRegistry->get($name) : null;
@@ -153,7 +154,7 @@ class QueueController extends AbstractController
         return new JsonResponse($queueData);
     }
 
-    #[Route(path: '/queue', name: 'api.frosh.tools.queue.clear', defaults: ['_acl' => ['frosh_tools:update']], methods: ['DELETE'])]
+    #[Route(path: '/queue', name: 'api.frosh.tools.queue.clear', defaults: ['_acl' => [FroshToolsPrivileges::QUEUE_UPDATE]], methods: ['DELETE'])]
     public function resetQueue(): JsonResponse
     {
         $incrementer = $this->incrementer->get('message_queue');

--- a/src/Controller/ScheduledTaskController.php
+++ b/src/Controller/ScheduledTaskController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -18,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::SCHEDULED_TASK_UPDATE]])]
 class ScheduledTaskController extends AbstractController
 {
     /**

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\Sbom\CycloneDxSbomGenerator;
 use Frosh\Tools\Components\Security\Checker\SecurityCheckerInterface;
 use Frosh\Tools\Components\Security\SecurityCollection;
@@ -15,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::SECURITY_READ]])]
 class SecurityController extends AbstractController
 {
     /**

--- a/src/Controller/ShopmonController.php
+++ b/src/Controller/ShopmonController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
@@ -17,7 +18,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::SHOPMON_READ]])]
 class ShopmonController extends AbstractController
 {
     // Fixed id keeps setup idempotent and lets us find/remove the integration again.
@@ -35,7 +36,7 @@ class ShopmonController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/shopmon', name: 'api.frosh.tools.shopmon.setup', methods: ['POST'])]
+    #[Route(path: '/shopmon', name: 'api.frosh.tools.shopmon.setup', defaults: ['_acl' => [FroshToolsPrivileges::SHOPMON_UPDATE]], methods: ['POST'])]
     public function setup(Context $context): JsonResponse
     {
         $accessKey = EnvironmentHelper::getVariable('SHOPMON_ACCESS_KEY', AccessKeyHelper::generateAccessKey('integration'));
@@ -57,10 +58,15 @@ class ShopmonController extends AbstractController
                                 'app:read',
                                 'plugin:read',
                                 'scheduled_task:read',
-                                'frosh_tools:read',
+                                'scheduled_task:update',
+                                FroshToolsPrivileges::READ,
+                                FroshToolsPrivileges::CACHE_READ,
+                                FroshToolsPrivileges::CACHE_UPDATE,
+                                FroshToolsPrivileges::SCHEDULED_TASK_READ,
+                                FroshToolsPrivileges::SCHEDULED_TASK_UPDATE,
+                                FroshToolsPrivileges::SECURITY_READ,
                                 'system:clear:cache',
                                 'system:cache:info',
-                                'scheduled_task:update',
                             ],
                         ],
                     ],
@@ -88,7 +94,7 @@ class ShopmonController extends AbstractController
         return new JsonResponse($this->buildStatus($context));
     }
 
-    #[Route(path: '/shopmon', name: 'api.frosh.tools.shopmon.remove', methods: ['DELETE'])]
+    #[Route(path: '/shopmon', name: 'api.frosh.tools.shopmon.remove', defaults: ['_acl' => [FroshToolsPrivileges::SHOPMON_UPDATE]], methods: ['DELETE'])]
     public function remove(Context $context): JsonResponse
     {
         $context->scope(Context::SYSTEM_SCOPE, function (Context $context): void {

--- a/src/Controller/ShopwareFilesController.php
+++ b/src/Controller/ShopwareFilesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
@@ -23,7 +24,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[AutoconfigureTag('monolog.logger', ['channel' => 'frosh-tools'])]
-#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::SECURITY_READ]])]
 class ShopwareFilesController extends AbstractController
 {
     private const STATUS_OK = 0;
@@ -141,7 +142,7 @@ class ShopwareFilesController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/shopware-file/restore', name: 'api.frosh.tools.shopware-file.restore', methods: ['GET'])]
+    #[Route(path: '/shopware-file/restore', name: 'api.frosh.tools.shopware-file.restore', defaults: ['_acl' => [FroshToolsPrivileges::SECURITY_UPDATE]], methods: ['GET'])]
     public function restoreShopwareFile(Request $request, Context $context): JsonResponse
     {
         if ($this->shopwareVersion === Kernel::SHOPWARE_FALLBACK_VERSION) {

--- a/src/Controller/StatisticsController.php
+++ b/src/Controller/StatisticsController.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Components\CacheStatisticsService;
 use Frosh\Tools\Components\DatabaseStatisticsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
-#[Route(path: '/api/_action/frosh-tools/statistics', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+#[Route(path: '/api/_action/frosh-tools/statistics', defaults: ['_routeScope' => ['api'], '_acl' => [FroshToolsPrivileges::READ]])]
 class StatisticsController extends AbstractController
 {
     public function __construct(

--- a/src/Resources/app/administration/src/module/frosh-tools/acl/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/acl/index.js
@@ -1,15 +1,116 @@
-Shopware.Service('privileges').addPrivilegeMappingEntry({
-    category: 'additional_permissions',
-    parent: null,
+import { PRIVILEGE } from './privileges';
+
+const privileges = Shopware.Service('privileges');
+
+function registerArea({ key, viewer, editor = null, extraViewer = [], extraEditor = [] }) {
+    const roles = {
+        viewer: {
+            privileges: [viewer, PRIVILEGE.READ, ...extraViewer],
+            dependencies: [],
+        },
+    };
+
+    if (editor) {
+        roles.editor = {
+            privileges: [editor, ...extraEditor],
+            dependencies: [`${key}.viewer`],
+        };
+    }
+
+    privileges.addPrivilegeMappingEntry({
+        category: 'permissions',
+        parent: 'settings',
+        key,
+        roles,
+    });
+}
+
+// Overview: health, performance, statistics, feature flags, state machines.
+privileges.addPrivilegeMappingEntry({
+    category: 'permissions',
+    parent: 'settings',
     key: 'frosh_tools',
     roles: {
         viewer: {
-            privileges: ['frosh_tools:read'],
+            privileges: [
+                PRIVILEGE.READ,
+                'state_machine:read',
+                'state_machine_state:read',
+                'state_machine_transition:read',
+            ],
             dependencies: [],
         },
         editor: {
-            privileges: ['frosh_tools:update'],
-            dependencies: ['frosh_tools.viewer'],
+            privileges: [
+                PRIVILEGE.CACHE_UPDATE,
+                PRIVILEGE.QUEUE_UPDATE,
+                PRIVILEGE.SCHEDULED_TASK_UPDATE,
+                PRIVILEGE.ELASTICSEARCH_UPDATE,
+                PRIVILEGE.SECURITY_UPDATE,
+                PRIVILEGE.FASTLY_UPDATE,
+                PRIVILEGE.SHOPMON_UPDATE,
+            ],
+            dependencies: [
+                'frosh_tools.viewer',
+                'frosh_tools_cache.viewer',
+                'frosh_tools_queue.viewer',
+                'frosh_tools_scheduled_task.viewer',
+                'frosh_tools_elasticsearch.viewer',
+                'frosh_tools_logs.viewer',
+                'frosh_tools_security.viewer',
+                'frosh_tools_fastly.viewer',
+                'frosh_tools_shopmon.viewer',
+            ],
         },
     },
+});
+
+registerArea({
+    key: 'frosh_tools_cache',
+    viewer: PRIVILEGE.CACHE_READ,
+    editor: PRIVILEGE.CACHE_UPDATE,
+    extraEditor: ['sales_channel:read', 'theme:read', 'theme:update'],
+});
+
+registerArea({
+    key: 'frosh_tools_queue',
+    viewer: PRIVILEGE.QUEUE_READ,
+    editor: PRIVILEGE.QUEUE_UPDATE,
+});
+
+registerArea({
+    key: 'frosh_tools_scheduled_task',
+    viewer: PRIVILEGE.SCHEDULED_TASK_READ,
+    editor: PRIVILEGE.SCHEDULED_TASK_UPDATE,
+    extraViewer: ['scheduled_task:read'],
+    extraEditor: ['scheduled_task:update'],
+});
+
+registerArea({
+    key: 'frosh_tools_elasticsearch',
+    viewer: PRIVILEGE.ELASTICSEARCH_READ,
+    editor: PRIVILEGE.ELASTICSEARCH_UPDATE,
+});
+
+registerArea({
+    key: 'frosh_tools_logs',
+    viewer: PRIVILEGE.LOGS_READ,
+});
+
+registerArea({
+    key: 'frosh_tools_security',
+    viewer: PRIVILEGE.SECURITY_READ,
+    editor: PRIVILEGE.SECURITY_UPDATE,
+});
+
+registerArea({
+    key: 'frosh_tools_fastly',
+    viewer: PRIVILEGE.FASTLY_READ,
+    editor: PRIVILEGE.FASTLY_UPDATE,
+});
+
+registerArea({
+    key: 'frosh_tools_shopmon',
+    viewer: PRIVILEGE.SHOPMON_READ,
+    editor: PRIVILEGE.SHOPMON_UPDATE,
 });

--- a/src/Resources/app/administration/src/module/frosh-tools/acl/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/acl/index.js
@@ -2,7 +2,13 @@ import { PRIVILEGE } from './privileges';
 
 const privileges = Shopware.Service('privileges');
 
-function registerArea({ key, viewer, editor = null, extraViewer = [], extraEditor = [] }) {
+function registerArea({
+    key,
+    viewer,
+    editor = null,
+    extraViewer = [],
+    extraEditor = [],
+}) {
     const roles = {
         viewer: {
             privileges: [viewer, PRIVILEGE.READ, ...extraViewer],

--- a/src/Resources/app/administration/src/module/frosh-tools/acl/privileges.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/acl/privileges.js
@@ -1,0 +1,29 @@
+/**
+ * Privilege strings — keep in sync with Frosh\Tools\Acl\FroshToolsPrivileges.
+ */
+export const PRIVILEGE = {
+    READ: 'frosh_tools:read',
+
+    CACHE_READ: 'frosh_tools_cache:read',
+    CACHE_UPDATE: 'frosh_tools_cache:update',
+
+    QUEUE_READ: 'frosh_tools_queue:read',
+    QUEUE_UPDATE: 'frosh_tools_queue:update',
+
+    SCHEDULED_TASK_READ: 'frosh_tools_scheduled_task:read',
+    SCHEDULED_TASK_UPDATE: 'frosh_tools_scheduled_task:update',
+
+    ELASTICSEARCH_READ: 'frosh_tools_elasticsearch:read',
+    ELASTICSEARCH_UPDATE: 'frosh_tools_elasticsearch:update',
+
+    LOGS_READ: 'frosh_tools_logs:read',
+
+    SECURITY_READ: 'frosh_tools_security:read',
+    SECURITY_UPDATE: 'frosh_tools_security:update',
+
+    FASTLY_READ: 'frosh_tools_fastly:read',
+    FASTLY_UPDATE: 'frosh_tools_fastly:update',
+
+    SHOPMON_READ: 'frosh_tools_shopmon:read',
+    SHOPMON_UPDATE: 'frosh_tools_shopmon:update',
+};

--- a/src/Resources/app/administration/src/module/frosh-tools/acl/privileges.spec.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/acl/privileges.spec.js
@@ -12,10 +12,10 @@ describe('frosh-tools privileges', () => {
         expect(new Set(reads).size).toBe(reads.length);
         expect(new Set(updates).size).toBe(updates.length);
         expect(reads.some((privilege) => updates.includes(privilege))).toBe(
-            false
+            false,
         );
-        expect(updates.every((privilege) => privilege.endsWith(':update'))).toBe(
-            true
-        );
+        expect(
+            updates.every((privilege) => privilege.endsWith(':update')),
+        ).toBe(true);
     });
 });

--- a/src/Resources/app/administration/src/module/frosh-tools/acl/privileges.spec.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/acl/privileges.spec.js
@@ -12,10 +12,10 @@ describe('frosh-tools privileges', () => {
         expect(new Set(reads).size).toBe(reads.length);
         expect(new Set(updates).size).toBe(updates.length);
         expect(reads.some((privilege) => updates.includes(privilege))).toBe(
-            false,
+            false
         );
         expect(
-            updates.every((privilege) => privilege.endsWith(':update')),
+            updates.every((privilege) => privilege.endsWith(':update'))
         ).toBe(true);
     });
 });

--- a/src/Resources/app/administration/src/module/frosh-tools/acl/privileges.spec.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/acl/privileges.spec.js
@@ -1,0 +1,21 @@
+import { PRIVILEGE } from './privileges';
+
+describe('frosh-tools privileges', () => {
+    it('keeps read and update privileges on separate keys', () => {
+        const reads = Object.entries(PRIVILEGE)
+            .filter(([key]) => key.endsWith('_READ') || key === 'READ')
+            .map(([, value]) => value);
+        const updates = Object.entries(PRIVILEGE)
+            .filter(([key]) => key.endsWith('_UPDATE'))
+            .map(([, value]) => value);
+
+        expect(new Set(reads).size).toBe(reads.length);
+        expect(new Set(updates).size).toBe(updates.length);
+        expect(reads.some((privilege) => updates.includes(privilege))).toBe(
+            false
+        );
+        expect(updates.every((privilege) => privilege.endsWith(':update'))).toBe(
+            true
+        );
+    });
+});

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-files/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-files/index.js
@@ -1,6 +1,7 @@
 import template from './template.twig';
 import './style.scss';
 import DiffMatchPatch from 'diff-match-patch';
+import { PRIVILEGE } from '../../acl/privileges';
 
 const { Component, Mixin } = Shopware;
 
@@ -9,7 +10,7 @@ const { Component, Mixin } = Shopware;
 // so it lives on its own sub-tab inside the Security Center.
 Component.register('frosh-tools-security-files', {
     template,
-    inject: ['froshToolsService'],
+    inject: ['froshToolsService', 'acl'],
     mixins: [
         Mixin.getByName('notification'),
         Mixin.getByName('frosh-sortable-table'),
@@ -26,6 +27,12 @@ Component.register('frosh-tools-security-files', {
             },
             showModal: false,
         };
+    },
+
+    computed: {
+        canUpdate() {
+            return this.acl.can(PRIVILEGE.SECURITY_UPDATE);
+        },
     },
 
     created() {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-files/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-security-files/template.twig
@@ -98,6 +98,7 @@
                 {{ $t('global.default.close') }}
             </button>
             <button
+                v-if="canUpdate"
                 class="ft-btn ft-btn--danger"
                 @click="restoreFile(diffData.file.name)"
                 :disabled="diffData.file.expected"

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-cache/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-cache/index.js
@@ -1,5 +1,6 @@
 import template from './template.twig';
 import './style.scss';
+import { PRIVILEGE } from '../../acl/privileges';
 
 const { Component, Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
@@ -11,6 +12,7 @@ Component.register('frosh-tools-tab-cache', {
         froshToolsService: { from: 'froshToolsService' },
         repositoryFactory: { from: 'repositoryFactory' },
         themeService: { from: 'themeService' },
+        acl: { from: 'acl' },
         froshToolsSearch: { default: null },
     },
     mixins: [
@@ -83,6 +85,10 @@ Component.register('frosh-tools-tab-cache', {
 
         salesChannelRepository() {
             return this.repositoryFactory.create('sales_channel');
+        },
+
+        canUpdate() {
+            return this.acl.can(PRIVILEGE.CACHE_UPDATE);
         },
     },
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-cache/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-cache/template.twig
@@ -9,6 +9,7 @@
                 @click="createdComponent"
             />
             <button
+                v-if="canUpdate"
                 class="ft-btn"
                 @click="compileTheme"
                 :disabled="isLoading"
@@ -19,6 +20,7 @@
                 </span>
             </button>
             <button
+                v-if="canUpdate"
                 class="ft-btn ft-btn--primary"
                 @click="clearOPcache"
                 :disabled="isLoading"
@@ -81,7 +83,10 @@
                             sort-key="freeSpace"
                             class="ft-table__num"
                         >{{ $t('frosh-tools.free') }}</ft-th-sort>
-                        <th class="ft-table__actions">
+                        <th
+                            v-if="canUpdate"
+                            class="ft-table__actions"
+                        >
                             {{ $t('frosh-tools.actions') }}
                         </th>
                     </tr>
@@ -121,7 +126,10 @@
                                 {{ formatSize(item.freeSpace) }}
                             </template>
                         </td>
-                        <td class="ft-table__actions">
+                        <td
+                            v-if="canUpdate"
+                            class="ft-table__actions"
+                        >
                             <button
                                 class="ft-btn ft-btn--danger"
                                 @click="clearCache(item)"

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/index.js
@@ -1,5 +1,6 @@
 import template from './template.twig';
 import './style.scss';
+import { PRIVILEGE } from '../../acl/privileges';
 
 const { Mixin, Component } = Shopware;
 
@@ -8,6 +9,7 @@ Component.register('frosh-tools-tab-elasticsearch', {
 
     inject: {
         froshElasticSearch: { from: 'froshElasticSearch' },
+        acl: { from: 'acl' },
         froshToolsSearch: { default: null },
     },
     mixins: [
@@ -39,6 +41,10 @@ Component.register('frosh-tools-tab-elasticsearch', {
 
         visibleIndices() {
             return this.filterRows(this.indices, this.searchTerm, ['name']);
+        },
+
+        canUpdate() {
+            return this.acl.can(PRIVILEGE.ELASTICSEARCH_UPDATE);
         },
 
         engineName() {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/index.spec.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/index.spec.js
@@ -18,7 +18,7 @@ function createService() {
     };
 }
 
-async function createWrapper(service) {
+async function createWrapper(service, { canUpdate = true } = {}) {
     const [component, ftModal] = await Promise.all([
         Shopware.Component.build('frosh-tools-tab-elasticsearch'),
         Shopware.Component.build('ft-modal'),
@@ -26,7 +26,14 @@ async function createWrapper(service) {
 
     return mount(component, {
         global: {
-            provide: { froshElasticSearch: service },
+            provide: {
+                froshElasticSearch: service,
+                acl: {
+                    can: (privilege) =>
+                        canUpdate ||
+                        privilege !== 'frosh_tools_elasticsearch:update',
+                },
+            },
             components: { 'ft-modal': ftModal },
             stubs: [
                 'ft-page-head',
@@ -55,6 +62,18 @@ async function createWrapper(service) {
 describe('frosh-tools-tab-elasticsearch destructive actions', () => {
     afterEach(() => {
         document.body.innerHTML = '';
+    });
+
+    it('hides destructive index actions when the user cannot update', async () => {
+        const service = createService();
+        service.indices.mockResolvedValue([
+            { name: 'shopware-product', aliases: [], indexSize: 1, docs: 1 },
+        ]);
+        const wrapper = await createWrapper(service, { canUpdate: false });
+        await flushPromises();
+
+        expect(wrapper.vm.canUpdate).toBe(false);
+        expect(wrapper.find('.ft-table__actions').exists()).toBe(false);
     });
 
     it('asks for confirmation before deleting an index', async () => {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-elasticsearch/template.twig
@@ -66,12 +66,14 @@
         >
             <template #actions>
                 <button
+                    v-if="canUpdate"
                     class="ft-btn ft-btn--primary"
                     @click="reindex"
                 >
                     {{ $t('frosh-tools.tabs.elasticsearch.action.reindex') }}
                 </button>
                 <button
+                    v-if="canUpdate"
                     class="ft-btn"
                     @click="switchAlias"
                 >
@@ -95,6 +97,7 @@
                     {{ $t('frosh-tools.tabs.elasticsearch.action.showUnused') }}
                 </button>
                 <button
+                    v-if="canUpdate"
                     class="ft-btn"
                     v-tooltip="{
                         showDelay: 300,
@@ -112,6 +115,7 @@
                     {{ $t('frosh-tools.tabs.elasticsearch.action.cleanup') }}
                 </button>
                 <button
+                    v-if="canUpdate"
                     class="ft-btn ft-btn--danger"
                     v-tooltip="{
                         showDelay: 300,
@@ -135,12 +139,14 @@
                     {{ $t('frosh-tools.tabs.elasticsearch.action.cleanupOrphaned') }}
                 </button>
                 <button
+                    v-if="canUpdate"
                     class="ft-btn ft-btn--danger"
                     @click="askFlushAll"
                 >
                     {{ $t('frosh-tools.tabs.elasticsearch.action.flushAll') }}
                 </button>
                 <button
+                    v-if="canUpdate"
                     class="ft-btn ft-btn--danger"
                     @click="askReset"
                 >
@@ -172,7 +178,10 @@
                                 sort-key="docs"
                                 class="ft-table__num"
                             >{{ $t('frosh-tools.docs') }}</ft-th-sort>
-                            <th class="ft-table__actions">
+                            <th
+                                v-if="canUpdate"
+                                class="ft-table__actions"
+                            >
                                 {{ $t('frosh-tools.actions') }}
                             </th>
                         </tr>
@@ -197,7 +206,10 @@
                             <td class="ft-table__num">
                                 {{ Number(item.docs).toLocaleString() }}
                             </td>
-                            <td class="ft-table__actions">
+                            <td
+                                v-if="canUpdate"
+                                class="ft-table__actions"
+                            >
                                 <button
                                     class="ft-btn ft-btn--danger"
                                     @click="askDeleteIndex(item.name)"
@@ -212,6 +224,7 @@
             </div>
         </ft-panel>
         <ft-panel
+            v-if="canUpdate"
             :title="$t('frosh-tools.tabs.elasticsearch.console.title', { engine: engineName })"
         >
             <template #actions>

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-fastly/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-fastly/index.js
@@ -1,11 +1,12 @@
 import template from './template.twig';
 import './frosh-tools-tab-fastly.scss';
+import { PRIVILEGE } from '../../acl/privileges';
 
 const { Component, Mixin } = Shopware;
 
 Component.register('frosh-tools-tab-fastly', {
     template,
-    inject: ['froshToolsService'],
+    inject: ['froshToolsService', 'acl'],
     mixins: [
         Mixin.getByName('notification'),
         Mixin.getByName('frosh-sortable-table'),
@@ -51,6 +52,10 @@ Component.register('frosh-tools-tab-fastly', {
                     label: this.$t('frosh-tools.tabs.fastly.timeframes.30d'),
                 },
             ];
+        },
+
+        canUpdate() {
+            return this.acl.can(PRIVILEGE.FASTLY_UPDATE);
         },
     },
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-fastly/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-fastly/template.twig
@@ -50,7 +50,10 @@
             <dd>{{ formatNumber(stats.hits) }}</dd>
         </dl>
     </ft-panel>
-    <ft-panel title="Purge controls">
+    <ft-panel
+        v-if="canUpdate"
+        title="Purge controls"
+    >
         <p class="frosh-tab-fastly__desc">
             {{ $t('frosh-tools.tabs.fastly.description') }}
         </p>

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/index.js
@@ -1,5 +1,6 @@
 import template from './template.twig';
 import './style.scss';
+import { PRIVILEGE } from '../../acl/privileges';
 
 const { Component, Mixin } = Shopware;
 
@@ -47,6 +48,10 @@ Component.register('frosh-tools-tab-queue', {
                 'name',
                 'type',
             ]);
+        },
+
+        canUpdate() {
+            return this.acl.can(PRIVILEGE.QUEUE_UPDATE);
         },
     },
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-queue/template.twig
@@ -9,7 +9,7 @@
                 @click="refresh"
             />
             <ft-button
-                v-if="acl.can('frosh_tools:update')"
+                v-if="canUpdate"
                 variant="danger"
                 icon="trash"
                 @click="showResetModal = true"
@@ -131,7 +131,7 @@
                                 {{ $t('frosh-tools.tabs.queue.transports.browse') }}
                             </button>
                             <ft-button
-                                v-if="transport.purgeable && acl.can('frosh_tools:update')"
+                                v-if="transport.purgeable && canUpdate"
                                 variant="danger"
                                 icon="trash"
                                 class="frosh-tab-queue__purge-btn"
@@ -290,7 +290,7 @@
                         >{{ stamp }}</ft-pill>
                     </div>
                     <div
-                        v-if="message.id && acl.can('frosh_tools:update') && (browseTransport.retryable || browseTransport.removable)"
+                        v-if="message.id && canUpdate && (browseTransport.retryable || browseTransport.removable)"
                         class="frosh-tab-queue__message-actions"
                     >
                         <ft-button

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/index.js
@@ -1,5 +1,6 @@
 import template from './template.twig';
 import './style.scss';
+import { PRIVILEGE } from '../../acl/privileges';
 
 const { Component, Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
@@ -9,6 +10,7 @@ Component.register('frosh-tools-tab-scheduled', {
     inject: {
         repositoryFactory: { from: 'repositoryFactory' },
         froshToolsService: { from: 'froshToolsService' },
+        acl: { from: 'acl' },
         froshToolsSearch: { default: null },
     },
     mixins: [
@@ -58,6 +60,10 @@ Component.register('frosh-tools-tab-scheduled', {
 
         dateFilter() {
             return Shopware.Filter.getByName('date');
+        },
+
+        canUpdate() {
+            return this.acl.can(PRIVILEGE.SCHEDULED_TASK_UPDATE);
         },
     },
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/index.spec.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/index.spec.js
@@ -44,7 +44,7 @@ async function createWrapper({ searchTerm = '', canUpdate = true } = {}) {
     };
 
     const component = await Shopware.Component.build(
-        'frosh-tools-tab-scheduled',
+        'frosh-tools-tab-scheduled'
     );
 
     return mount(component, {
@@ -95,7 +95,7 @@ describe('frosh-tools-tab-scheduled search', () => {
 
         expect(wrapper.vm.canUpdate).toBe(false);
         expect(wrapper.find('.frosh-tab-scheduled__menu-wrap').exists()).toBe(
-            false,
+            false
         );
     });
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/index.spec.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/index.spec.js
@@ -37,7 +37,7 @@ const STUBS = {
     'sw-datepicker': true,
 };
 
-async function createWrapper({ searchTerm = '' } = {}) {
+async function createWrapper({ searchTerm = '', canUpdate = true } = {}) {
     const scheduledRepository = {
         search: jest.fn().mockResolvedValue(TASKS),
         save: jest.fn().mockResolvedValue({}),
@@ -52,6 +52,10 @@ async function createWrapper({ searchTerm = '' } = {}) {
             provide: {
                 repositoryFactory: { create: () => scheduledRepository },
                 froshToolsService: {},
+                acl: {
+                    can: (privilege) =>
+                        canUpdate || privilege !== 'frosh_tools_scheduled_task:update',
+                },
                 froshToolsSearch: { searchTerm },
             },
             stubs: STUBS,
@@ -82,6 +86,16 @@ describe('frosh-tools-tab-scheduled search', () => {
         const rows = wrapper.findAll('tbody tr');
         expect(rows).toHaveLength(1);
         expect(rows[0].text()).toContain('log_entry.cleanup');
+    });
+
+    it('hides task actions when the user cannot update', async () => {
+        const wrapper = await createWrapper({ canUpdate: false });
+        await flushPromises();
+
+        expect(wrapper.vm.canUpdate).toBe(false);
+        expect(wrapper.find('.frosh-tab-scheduled__menu-wrap').exists()).toBe(
+            false
+        );
     });
 
     it('shows a no-results state when nothing matches', async () => {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/index.spec.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/index.spec.js
@@ -44,7 +44,7 @@ async function createWrapper({ searchTerm = '', canUpdate = true } = {}) {
     };
 
     const component = await Shopware.Component.build(
-        'frosh-tools-tab-scheduled'
+        'frosh-tools-tab-scheduled',
     );
 
     return mount(component, {
@@ -54,7 +54,8 @@ async function createWrapper({ searchTerm = '', canUpdate = true } = {}) {
                 froshToolsService: {},
                 acl: {
                     can: (privilege) =>
-                        canUpdate || privilege !== 'frosh_tools_scheduled_task:update',
+                        canUpdate ||
+                        privilege !== 'frosh_tools_scheduled_task:update',
                 },
                 froshToolsSearch: { searchTerm },
             },
@@ -94,7 +95,7 @@ describe('frosh-tools-tab-scheduled search', () => {
 
         expect(wrapper.vm.canUpdate).toBe(false);
         expect(wrapper.find('.frosh-tab-scheduled__menu-wrap').exists()).toBe(
-            false
+            false,
         );
     });
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-scheduled/template.twig
@@ -9,6 +9,7 @@
                 @click="refresh"
             />
             <button
+                v-if="canUpdate"
                 class="ft-btn ft-btn--primary"
                 :disabled="isLoading"
                 @click="registerScheduledTasks"
@@ -80,6 +81,7 @@
                             style="width: 130px;"
                         >{{ $t('frosh-tools.status') }}</ft-th-sort>
                         <th
+                            v-if="canUpdate"
                             class="ft-table__actions"
                             style="width: 60px;"
                         ></th>
@@ -106,7 +108,10 @@
                         <td>
                             <ft-pill :variant="statusVariant(item.status)">{{ item.status }}</ft-pill>
                         </td>
-                        <td class="ft-table__actions">
+                        <td
+                            v-if="canUpdate"
+                            class="ft-table__actions"
+                        >
                             <div class="frosh-tab-scheduled__menu-wrap">
                                 <button
                                     class="ft-btn ft-btn--ghost ft-btn--icon"

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/index.js
@@ -1,11 +1,12 @@
 import template from './template.twig';
 import './style.scss';
+import { PRIVILEGE } from '../../acl/privileges';
 
 const { Component, Mixin } = Shopware;
 
 Component.register('frosh-tools-tab-shopmon', {
     template,
-    inject: ['froshToolsService'],
+    inject: ['froshToolsService', 'acl'],
     mixins: [Mixin.getByName('notification')],
 
     data() {
@@ -21,6 +22,10 @@ Component.register('frosh-tools-tab-shopmon', {
     computed: {
         isConfigured() {
             return this.status?.configured === true;
+        },
+
+        canUpdate() {
+            return this.acl.can(PRIVILEGE.SHOPMON_UPDATE);
         },
     },
 

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/template.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-shopmon/template.twig
@@ -24,6 +24,7 @@
             </p>
             <div class="frosh-tab-shopmon__cta">
                 <button
+                    v-if="canUpdate"
                     class="frosh-tab-shopmon__cta-primary"
                     :disabled="isSettingUp"
                     @click="setup"
@@ -115,6 +116,7 @@
                     </span>
                 </a>
                 <button
+                    v-if="canUpdate"
                     class="ft-btn ft-btn--danger"
                     @click="showRemoveModal = true"
                 >

--- a/src/Resources/app/administration/src/module/frosh-tools/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/index.js
@@ -26,6 +26,7 @@ import './component/frosh-tools-tab-statistics';
 import './component/frosh-tools-tab-shopmon';
 import './page/index';
 import './acl';
+import { PRIVILEGE } from './acl/privileges';
 
 Shopware.Module.register('frosh-tools', {
     type: 'plugin',
@@ -45,7 +46,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-index',
                     path: 'index',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -53,7 +54,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-cache',
                     path: 'cache',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.CACHE_READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -61,7 +62,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-queue',
                     path: 'queue',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.QUEUE_READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -69,7 +70,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-scheduled',
                     path: 'scheduled',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.SCHEDULED_TASK_READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -77,7 +78,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-elasticsearch',
                     path: 'elasticsearch',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.ELASTICSEARCH_READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -85,7 +86,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-feature-flags',
                     path: 'feature-flags',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.READ,
                         parentPath: 'frosh.tools.index.index',
                     },
                 },
@@ -93,7 +94,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-logs',
                     path: 'logs',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.LOGS_READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -101,7 +102,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-security',
                     path: 'security',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.SECURITY_READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -109,7 +110,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-state-machines',
                     path: 'state-machines',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -117,7 +118,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-fastly',
                     path: 'fastly',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.FASTLY_READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -125,7 +126,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-statistics',
                     path: 'statistics',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -133,7 +134,7 @@ Shopware.Module.register('frosh-tools', {
                     component: 'frosh-tools-tab-shopmon',
                     path: 'shopmon',
                     meta: {
-                        privilege: 'frosh_tools:read',
+                        privilege: PRIVILEGE.SHOPMON_READ,
                         parentPath: 'sw.settings.index.plugins',
                     },
                 },
@@ -144,11 +145,11 @@ Shopware.Module.register('frosh-tools', {
     settingsItem: [
         {
             group: 'plugins',
-            to: 'frosh.tools.index.cache',
+            to: 'frosh.tools.index.index',
             icon: 'regular-cog',
             name: 'frosh-tools',
             label: 'frosh-tools.title',
-            privilege: 'frosh_tools:read',
+            privilege: PRIVILEGE.READ,
         },
     ],
 });

--- a/src/Resources/app/administration/src/module/frosh-tools/page/index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/page/index/index.js
@@ -1,6 +1,7 @@
 import '../../styles/design-system.scss';
 import './frosh-tools.scss';
 import template from './template.twig';
+import { PRIVILEGE } from '../../acl/privileges';
 
 const { Component } = Shopware;
 
@@ -47,7 +48,7 @@ const SEARCHABLE_TABS = {
 
 Component.register('frosh-tools-index', {
     template,
-    inject: ['froshToolsService'],
+    inject: ['froshToolsService', 'acl'],
 
     provide() {
         // Tabs inject this component as `froshToolsSearch` and read
@@ -105,14 +106,17 @@ Component.register('frosh-tools-index', {
                 {
                     route: 'frosh.tools.index.index',
                     labelKey: 'frosh-tools.tabs.index.title',
+                    privilege: PRIVILEGE.READ,
                 },
                 {
                     route: 'frosh.tools.index.security',
                     labelKey: 'frosh-tools.tabs.security.title',
+                    privilege: PRIVILEGE.SECURITY_READ,
                 },
                 {
                     route: 'frosh.tools.index.shopmon',
                     labelKey: 'frosh-tools.tabs.shopmon.title',
+                    privilege: PRIVILEGE.SHOPMON_READ,
                 },
             ];
 
@@ -120,16 +124,19 @@ Component.register('frosh-tools-index', {
                 {
                     route: 'frosh.tools.index.cache',
                     labelKey: 'frosh-tools.tabs.cache.title',
+                    privilege: PRIVILEGE.CACHE_READ,
                 },
                 {
                     route: 'frosh.tools.index.statistics',
                     labelKey: 'frosh-tools.tabs.statistics.title',
+                    privilege: PRIVILEGE.READ,
                 },
             ];
             if (this.elasticsearchAvailable) {
                 performance.push({
                     route: 'frosh.tools.index.elasticsearch',
                     labelKey: 'frosh-tools.tabs.elasticsearch.title',
+                    privilege: PRIVILEGE.ELASTICSEARCH_READ,
                 });
             }
 
@@ -137,14 +144,17 @@ Component.register('frosh-tools-index', {
                 {
                     route: 'frosh.tools.index.queue',
                     labelKey: 'frosh-tools.tabs.queue.title',
+                    privilege: PRIVILEGE.QUEUE_READ,
                 },
                 {
                     route: 'frosh.tools.index.scheduled',
                     labelKey: 'frosh-tools.tabs.scheduledTaskOverview.title',
+                    privilege: PRIVILEGE.SCHEDULED_TASK_READ,
                 },
                 {
                     route: 'frosh.tools.index.statemachines',
                     labelKey: 'frosh-tools.tabs.state-machines.title',
+                    privilege: PRIVILEGE.READ,
                 },
             ];
 
@@ -153,11 +163,13 @@ Component.register('frosh-tools-index', {
                 diagnostics.push({
                     route: 'frosh.tools.index.logs',
                     labelKey: 'frosh-tools.tabs.logs.title',
+                    privilege: PRIVILEGE.LOGS_READ,
                 });
             }
             diagnostics.push({
                 route: 'frosh.tools.index.featureflags',
                 labelKey: 'frosh-tools.tabs.feature-flags.title',
+                privilege: PRIVILEGE.READ,
             });
 
             const cdn = [];
@@ -165,6 +177,7 @@ Component.register('frosh-tools-index', {
                 cdn.push({
                     route: 'frosh.tools.index.fastly',
                     labelKey: 'frosh-tools.tabs.fastly.title',
+                    privilege: PRIVILEGE.FASTLY_READ,
                 });
             }
 
@@ -174,7 +187,14 @@ Component.register('frosh-tools-index', {
                 { labelKey: 'frosh-tools.nav.operations', items: operations },
                 { labelKey: 'frosh-tools.nav.diagnostics', items: diagnostics },
                 { labelKey: 'frosh-tools.nav.cdn', items: cdn },
-            ];
+            ]
+                .map((group) => ({
+                    ...group,
+                    items: group.items.filter((item) =>
+                        this.acl.can(item.privilege)
+                    ),
+                }))
+                .filter((group) => group.items.length);
         },
     },
 

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -502,10 +502,33 @@
         }
     },
     "sw-privileges": {
-        "additional_permissions": {
+        "permissions": {
             "frosh_tools": {
-                "frosh_tools": "Überwachung anzeigen",
-                "label": "Frosh tools"
+                "label": "Frosh Tools"
+            },
+            "frosh_tools_cache": {
+                "label": "Frosh Tools — Cache"
+            },
+            "frosh_tools_queue": {
+                "label": "Frosh Tools — Warteschlange"
+            },
+            "frosh_tools_scheduled_task": {
+                "label": "Frosh Tools — Geplante Aufgaben"
+            },
+            "frosh_tools_elasticsearch": {
+                "label": "Frosh Tools — Suchindizes"
+            },
+            "frosh_tools_logs": {
+                "label": "Frosh Tools — Logs"
+            },
+            "frosh_tools_security": {
+                "label": "Frosh Tools — Sicherheit"
+            },
+            "frosh_tools_fastly": {
+                "label": "Frosh Tools — Fastly"
+            },
+            "frosh_tools_shopmon": {
+                "label": "Frosh Tools — Shopmon"
             }
         }
     },

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -502,10 +502,33 @@
         }
     },
     "sw-privileges": {
-        "additional_permissions": {
+        "permissions": {
             "frosh_tools": {
-                "frosh_tools": "View monitoring",
-                "label": "Frosh tools"
+                "label": "Frosh Tools"
+            },
+            "frosh_tools_cache": {
+                "label": "Frosh Tools — Cache"
+            },
+            "frosh_tools_queue": {
+                "label": "Frosh Tools — Queue"
+            },
+            "frosh_tools_scheduled_task": {
+                "label": "Frosh Tools — Scheduled tasks"
+            },
+            "frosh_tools_elasticsearch": {
+                "label": "Frosh Tools — Search indices"
+            },
+            "frosh_tools_logs": {
+                "label": "Frosh Tools — Logs"
+            },
+            "frosh_tools_security": {
+                "label": "Frosh Tools — Security"
+            },
+            "frosh_tools_fastly": {
+                "label": "Frosh Tools — Fastly"
+            },
+            "frosh_tools_shopmon": {
+                "label": "Frosh Tools — Shopmon"
             }
         }
     },

--- a/tests/Acl/FroshToolsPrivilegesTest.php
+++ b/tests/Acl/FroshToolsPrivilegesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Acl;
+
+use Frosh\Tools\Acl\FroshToolsPrivileges;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FroshToolsPrivileges::class)]
+class FroshToolsPrivilegesTest extends TestCase
+{
+    public function testReadAndUpdateSetsDoNotOverlap(): void
+    {
+        $reads = FroshToolsPrivileges::allRead();
+        $updates = FroshToolsPrivileges::allUpdate();
+
+        static::assertSame($reads, array_values(array_unique($reads)));
+        static::assertSame($updates, array_values(array_unique($updates)));
+        static::assertSame([], array_values(array_intersect($reads, $updates)));
+    }
+
+    public function testPrivilegeStringsFollowShopwareConvention(): void
+    {
+        foreach (FroshToolsPrivileges::allRead() as $privilege) {
+            static::assertStringEndsWith(':read', $privilege);
+        }
+
+        foreach (FroshToolsPrivileges::allUpdate() as $privilege) {
+            static::assertStringEndsWith(':update', $privilege);
+        }
+    }
+}

--- a/tests/Controller/AclRouteTest.php
+++ b/tests/Controller/AclRouteTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Controller;
+
+use Frosh\Tools\Acl\FroshToolsPrivileges;
+use Frosh\Tools\Controller\CacheController;
+use Frosh\Tools\Controller\ComposerAuditController;
+use Frosh\Tools\Controller\ElasticsearchController;
+use Frosh\Tools\Controller\ExtensionFilesController;
+use Frosh\Tools\Controller\FastlyController;
+use Frosh\Tools\Controller\FeatureFlagController;
+use Frosh\Tools\Controller\HealthController;
+use Frosh\Tools\Controller\LogController;
+use Frosh\Tools\Controller\QueueController;
+use Frosh\Tools\Controller\ScheduledTaskController;
+use Frosh\Tools\Controller\SecurityController;
+use Frosh\Tools\Controller\ShopmonController;
+use Frosh\Tools\Controller\ShopwareFilesController;
+use Frosh\Tools\Controller\StatisticsController;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[CoversNothing]
+class AclRouteTest extends TestCase
+{
+    /**
+     * @param class-string $class
+     */
+    #[DataProvider('routes')]
+    public function testRouteRequiresExpectedPrivilege(string $class, string $method, string $privilege): void
+    {
+        static::assertSame([$privilege], $this->resolveAcl($class, $method));
+    }
+
+    public function testEveryControllerActionIsCovered(): void
+    {
+        $covered = [];
+        foreach (self::routes() as $row) {
+            $covered[$row[0] . '::' . $row[1]] = true;
+        }
+
+        foreach ($this->controllerClasses() as $class) {
+            $reflection = new \ReflectionClass($class);
+            foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                if ($method->getDeclaringClass()->getName() !== $class) {
+                    continue;
+                }
+
+                if ($method->getAttributes(Route::class) === []) {
+                    continue;
+                }
+
+                $key = $class . '::' . $method->getName();
+                static::assertArrayHasKey($key, $covered, \sprintf('Add %s to AclRouteTest::routes()', $key));
+            }
+        }
+    }
+
+    /**
+     * @return iterable<string, array{class-string, string, string}>
+     */
+    public static function routes(): iterable
+    {
+        yield 'health.status' => [HealthController::class, 'status', FroshToolsPrivileges::READ];
+        yield 'health.performance' => [HealthController::class, 'performanceStatus', FroshToolsPrivileges::READ];
+        yield 'health.ping' => [HealthController::class, 'pingStatus', FroshToolsPrivileges::READ];
+        yield 'statistics.cache' => [StatisticsController::class, 'cacheStatistics', FroshToolsPrivileges::READ];
+        yield 'statistics.database' => [StatisticsController::class, 'databaseStatistics', FroshToolsPrivileges::READ];
+        yield 'feature-flags.list' => [FeatureFlagController::class, 'list', FroshToolsPrivileges::READ];
+
+        yield 'cache.list' => [CacheController::class, 'cacheStatistics', FroshToolsPrivileges::CACHE_READ];
+        yield 'cache.clear' => [CacheController::class, 'clearCache', FroshToolsPrivileges::CACHE_UPDATE];
+        yield 'cache.opcache' => [CacheController::class, 'clearOpCache', FroshToolsPrivileges::CACHE_UPDATE];
+
+        yield 'queue.transports' => [QueueController::class, 'transports', FroshToolsPrivileges::QUEUE_READ];
+        yield 'queue.messages' => [QueueController::class, 'messages', FroshToolsPrivileges::QUEUE_READ];
+        yield 'queue.list' => [QueueController::class, 'list', FroshToolsPrivileges::QUEUE_READ];
+        yield 'queue.retry' => [QueueController::class, 'retryMessage', FroshToolsPrivileges::QUEUE_UPDATE];
+        yield 'queue.delete' => [QueueController::class, 'deleteMessage', FroshToolsPrivileges::QUEUE_UPDATE];
+        yield 'queue.purge' => [QueueController::class, 'purgeTransport', FroshToolsPrivileges::QUEUE_UPDATE];
+        yield 'queue.reset' => [QueueController::class, 'resetQueue', FroshToolsPrivileges::QUEUE_UPDATE];
+
+        yield 'scheduled.run' => [ScheduledTaskController::class, 'runTask', FroshToolsPrivileges::SCHEDULED_TASK_UPDATE];
+        yield 'scheduled.schedule' => [ScheduledTaskController::class, 'scheduleTask', FroshToolsPrivileges::SCHEDULED_TASK_UPDATE];
+        yield 'scheduled.deactivate' => [ScheduledTaskController::class, 'deactivateTask', FroshToolsPrivileges::SCHEDULED_TASK_UPDATE];
+        yield 'scheduled.register' => [ScheduledTaskController::class, 'registerTasks', FroshToolsPrivileges::SCHEDULED_TASK_UPDATE];
+
+        yield 'es.status' => [ElasticsearchController::class, 'status', FroshToolsPrivileges::ELASTICSEARCH_READ];
+        yield 'es.indices' => [ElasticsearchController::class, 'indices', FroshToolsPrivileges::ELASTICSEARCH_READ];
+        yield 'es.unused' => [ElasticsearchController::class, 'unusedIndices', FroshToolsPrivileges::ELASTICSEARCH_READ];
+        yield 'es.orphaned' => [ElasticsearchController::class, 'orphanedIndices', FroshToolsPrivileges::ELASTICSEARCH_READ];
+        yield 'es.delete' => [ElasticsearchController::class, 'deleteIndex', FroshToolsPrivileges::ELASTICSEARCH_UPDATE];
+        yield 'es.console' => [ElasticsearchController::class, 'console', FroshToolsPrivileges::ELASTICSEARCH_UPDATE];
+        yield 'es.flush' => [ElasticsearchController::class, 'flushAll', FroshToolsPrivileges::ELASTICSEARCH_UPDATE];
+        yield 'es.reindex' => [ElasticsearchController::class, 'reindex', FroshToolsPrivileges::ELASTICSEARCH_UPDATE];
+        yield 'es.alias' => [ElasticsearchController::class, 'switchAlias', FroshToolsPrivileges::ELASTICSEARCH_UPDATE];
+        yield 'es.cleanup' => [ElasticsearchController::class, 'deleteUnusedIndices', FroshToolsPrivileges::ELASTICSEARCH_UPDATE];
+        yield 'es.cleanup-orphaned' => [ElasticsearchController::class, 'deleteOrphanedIndices', FroshToolsPrivileges::ELASTICSEARCH_UPDATE];
+        yield 'es.reset' => [ElasticsearchController::class, 'reset', FroshToolsPrivileges::ELASTICSEARCH_UPDATE];
+
+        yield 'logs.files' => [LogController::class, 'getLogFiles', FroshToolsPrivileges::LOGS_READ];
+        yield 'logs.file' => [LogController::class, 'getLog', FroshToolsPrivileges::LOGS_READ];
+
+        yield 'security.status' => [SecurityController::class, 'status', FroshToolsPrivileges::SECURITY_READ];
+        yield 'security.sbom' => [SecurityController::class, 'sbom', FroshToolsPrivileges::SECURITY_READ];
+        yield 'security.audit' => [ComposerAuditController::class, 'audit', FroshToolsPrivileges::SECURITY_READ];
+        yield 'security.extensions' => [ExtensionFilesController::class, 'listExtensionFiles', FroshToolsPrivileges::SECURITY_READ];
+        yield 'security.files' => [ShopwareFilesController::class, 'listShopwareFiles', FroshToolsPrivileges::SECURITY_READ];
+        yield 'security.contents' => [ShopwareFilesController::class, 'getFileContents', FroshToolsPrivileges::SECURITY_READ];
+        yield 'security.restore' => [ShopwareFilesController::class, 'restoreShopwareFile', FroshToolsPrivileges::SECURITY_UPDATE];
+
+        yield 'fastly.status' => [FastlyController::class, 'status', FroshToolsPrivileges::FASTLY_READ];
+        yield 'fastly.stats' => [FastlyController::class, 'statistics', FroshToolsPrivileges::FASTLY_READ];
+        yield 'fastly.snippets' => [FastlyController::class, 'snippets', FroshToolsPrivileges::FASTLY_READ];
+        yield 'fastly.purge' => [FastlyController::class, 'purge', FroshToolsPrivileges::FASTLY_UPDATE];
+        yield 'fastly.purge-all' => [FastlyController::class, 'purgeAll', FroshToolsPrivileges::FASTLY_UPDATE];
+
+        yield 'shopmon.status' => [ShopmonController::class, 'status', FroshToolsPrivileges::SHOPMON_READ];
+        yield 'shopmon.setup' => [ShopmonController::class, 'setup', FroshToolsPrivileges::SHOPMON_UPDATE];
+        yield 'shopmon.remove' => [ShopmonController::class, 'remove', FroshToolsPrivileges::SHOPMON_UPDATE];
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function controllerClasses(): array
+    {
+        $classes = [];
+        foreach (glob(\dirname(__DIR__, 2) . '/src/Controller/*Controller.php') ?: [] as $file) {
+            $classes[] = 'Frosh\\Tools\\Controller\\' . basename($file, '.php');
+        }
+
+        sort($classes);
+
+        return $classes;
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return list<string>
+     */
+    private function resolveAcl(string $class, string $method): array
+    {
+        $classAcl = $this->aclFromAttributes((new \ReflectionClass($class))->getAttributes(Route::class));
+        $methodAcl = $this->aclFromAttributes((new \ReflectionMethod($class, $method))->getAttributes(Route::class));
+
+        return $methodAcl ?? $classAcl ?? [];
+    }
+
+    /**
+     * @param list<\ReflectionAttribute<Route>> $attributes
+     *
+     * @return list<string>|null
+     */
+    private function aclFromAttributes(array $attributes): ?array
+    {
+        foreach ($attributes as $attribute) {
+            $acl = $attribute->newInstance()->defaults['_acl'] ?? null;
+            if (\is_array($acl)) {
+                return array_values($acl);
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Controller/QueueControllerTest.php
+++ b/tests/Controller/QueueControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Tests\Controller;
 
+use Frosh\Tools\Acl\FroshToolsPrivileges;
 use Frosh\Tools\Controller\QueueController;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -19,7 +20,7 @@ class QueueControllerTest extends TestCase
         $attributes = (new \ReflectionMethod(QueueController::class, $method))->getAttributes(Route::class);
 
         static::assertCount(1, $attributes);
-        static::assertSame(['_acl' => ['frosh_tools:update']], $attributes[0]->newInstance()->defaults);
+        static::assertSame(['_acl' => [FroshToolsPrivileges::QUEUE_UPDATE]], $attributes[0]->newInstance()->defaults);
     }
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Almost every Tools API route and admin tab was gated by a single privilege (`frosh_tools:read`). `frosh_tools:update` existed only for a few queue mutations. Anyone who could open Tools could also clear caches, restore core files, purge Fastly, run scheduled tasks, and talk to Elasticsearch.

## Plan

Keep Shopware’s Viewer / Editor grid (same pattern as the webhook module) and split privileges **by tab / risk**, not by a single global flag.

| Permission row | Viewer | Editor |
| --- | --- | --- |
| **Frosh Tools** | Health, statistics, feature flags, state machines | Convenience: all Tools write privileges (depends on every area viewer) |
| **Cache** | List pools | Clear pool / OPcache, compile themes |
| **Queue** | List / browse | Retry, delete, purge, reset |
| **Scheduled tasks** | List (`scheduled_task:read`), including Symfony scheduler | Run / schedule / deactivate / register / edit / dispatch scheduler messages |
| **Search indices** | Status, indices, unused list | Reindex, delete, console, cleanup, reset |
| **Logs** | Read `var/log` | — |
| **Security** | Status, SBOM, file check, diffs | Restore files |
| **Fastly** | Status, stats, snippets | Purge |
| **Shopmon** | Status | Setup / remove |

`frosh_tools:read` remains the module entry + header health badge. Each area viewer also includes that privilege so a role can be given only Cache (or only Logs) and still open Tools.

## What changed

- New privilege constants in `FroshToolsPrivileges` (PHP) and `acl/privileges.js` (admin)
- Every `_action/frosh-tools` route now requires the area `:read` or `:update` privilege
- Admin routes, sidebar, and write buttons honor the same privileges
- Settings item lands on System Status instead of Cache
- Shopmon integration role updated for the new privilege names
- Route-attribute tests cover every controller action
- Merged latest `main` (Symfony scheduler): list uses `frosh_tools_scheduled_task:read`, run uses `:update`

## Breaking change

Roles that only had `frosh_tools:read` keep the overview tabs (status, statistics, feature flags, state machines). They lose cache / queue / tasks / Elasticsearch / logs / security / Fastly / Shopmon until those viewers (and editors) are ticked again. Super-admin is unchanged. Re-open the role after upgrade.

Webhook ACL is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a722c011-c2f9-41d2-abd6-4d1861b7d171?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a722c011-c2f9-41d2-abd6-4d1861b7d171&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

