### PR TITLE
feat: downgrade neverConsumed check from warning to info

### DIFF
--- a/src/Components/Health/Checker/HealthChecker/SymfonySchedulerChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/SymfonySchedulerChecker.php
@@ -79,13 +79,13 @@ class SymfonySchedulerChecker implements HealthCheckerInterface, CheckerInterfac
         }
 
         if ($evaluated === 0) {
-            $collection->add(SettingsResult::info('symfony_scheduler', self::SNIPPET, 'not monitored', $recommended));
+            $collection->add(SettingsResult::info('symfony_scheduler', self::SNIPPET, 'nothing to monitor', $recommended));
 
             return;
         }
 
         if ($neverRun !== []) {
-            $collection->add(SettingsResult::warning(
+            $collection->add(SettingsResult::info(
                 'symfony_scheduler',
                 self::SNIPPET,
                 \sprintf('never consumed (%s)', implode(', ', $neverRun)),

--- a/tests/Components/Health/Checker/HealthChecker/SymfonySchedulerCheckerTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/SymfonySchedulerCheckerTest.php
@@ -72,7 +72,7 @@ class SymfonySchedulerCheckerTest extends TestCase
             $this->schedule(name: 'example', checkpoint: null, dueDates: ['+1 day']),
         ]);
 
-        static::assertSame(SettingsResult::WARNING, $result->state);
+        static::assertSame(SettingsResult::INFO, $result->state);
         static::assertSame('never consumed (example)', $result->current);
     }
 
@@ -84,7 +84,7 @@ class SymfonySchedulerCheckerTest extends TestCase
         ]);
 
         static::assertSame(SettingsResult::INFO, $result->state);
-        static::assertSame('not monitored', $result->current);
+        static::assertSame('nothing to monitor', $result->current);
     }
 
     public function testTheWorstScheduleIsReported(): void


### PR DESCRIPTION
The check is okay, but after each deployment this will always start with a warning.
So we downgrade this.