### PR TITLE
Add error when shopware-installer.phar.php remains in public

### DIFF
--- a/src/Components/Health/Checker/HealthChecker/ShopwareInstallerChecker.php
+++ b/src/Components/Health/Checker/HealthChecker/ShopwareInstallerChecker.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\Health\Checker\HealthChecker;
+
+use Frosh\Tools\Components\Health\Checker\CheckerInterface;
+use Frosh\Tools\Components\Health\HealthCollection;
+use Frosh\Tools\Components\Health\SettingsResult;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * The Shopware web installer is downloaded as public/shopware-installer.phar.php.
+ * After installation it must be deleted: anyone who can request that URL can
+ * start a reinstall and overwrite the shop.
+ */
+class ShopwareInstallerChecker implements HealthCheckerInterface, CheckerInterface
+{
+    public const ID = 'shopware-installer';
+    public const FILE_NAME = 'shopware-installer.phar.php';
+
+    private const SNIPPET = 'Shopware installer';
+
+    public function __construct(
+        #[Autowire('%kernel.project_dir%/public')]
+        private readonly string $publicDir,
+    ) {
+    }
+
+    public function collect(HealthCollection $collection): void
+    {
+        if (is_file($this->publicDir . '/' . self::FILE_NAME)) {
+            $collection->add(SettingsResult::error(
+                self::ID,
+                self::SNIPPET,
+                'present in public directory',
+                'not present',
+            ));
+
+            return;
+        }
+
+        $collection->add(SettingsResult::ok(
+            self::ID,
+            self::SNIPPET,
+            'not present',
+            'not present',
+        ));
+    }
+}

--- a/src/Components/Security/Checker/ShopwareInstallerChecker.php
+++ b/src/Components/Security/Checker/ShopwareInstallerChecker.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\Security\Checker;
+
+use Frosh\Tools\Components\Security\SecurityCollection;
+use Frosh\Tools\Components\Security\SecurityFinding;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * The Shopware web installer is downloaded as public/shopware-installer.phar.php.
+ * After installation it must be deleted: anyone who can request that URL can
+ * start a reinstall and overwrite the shop.
+ */
+class ShopwareInstallerChecker implements SecurityCheckerInterface
+{
+    public const ID = 'shopware-installer';
+    public const FILE_NAME = 'shopware-installer.phar.php';
+
+    public function __construct(
+        #[Autowire('%kernel.project_dir%/public')]
+        private readonly string $publicDir,
+    ) {
+    }
+
+    public function collect(SecurityCollection $collection): void
+    {
+        if (is_file($this->publicDir . '/' . self::FILE_NAME)) {
+            $collection->add(SecurityFinding::critical(
+                self::ID,
+                SecurityFinding::CATEGORY_CONFIGURATION,
+                'Shopware installer',
+                'present in public directory',
+                'Delete public/shopware-installer.phar.php. The installer must not remain publicly accessible after installation',
+            ));
+
+            return;
+        }
+
+        $collection->add(SecurityFinding::ok(
+            self::ID,
+            SecurityFinding::CATEGORY_CONFIGURATION,
+            'Shopware installer',
+            'not present',
+        ));
+    }
+}

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-index/recommendations.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-index/recommendations.js
@@ -68,6 +68,12 @@ export default {
         description:
             'The highest amount of memory a single PHP-FPM worker has used. This is informational — use it to size memory_limit and to decide how many workers (pm.max_children) fit into the available RAM.',
     },
+    'shopware-installer': {
+        description:
+            'The Shopware web installer (shopware-installer.phar.php) is still in the public directory. Anyone who can request that URL can start a reinstall and overwrite the shop, so it is a security risk to leave it there after installation.',
+        solution:
+            'Delete public/shopware-installer.phar.php from the shop. The installer is only needed during the initial setup and must not stay publicly accessible.',
+    },
     'composer-conflicts-repository': {
         description:
             'The Shopware conflicts repository (https://shopware.github.io/conflicts/) is not registered in the "repositories" section of your root composer.json. This repository declares combinations of packages and versions that are known to be incompatible. With it in place, Composer refuses to install or update to a broken combination before it reaches production; without it those guard rails are missing.',

--- a/tests/Components/Health/Checker/HealthChecker/ShopwareInstallerCheckerTest.php
+++ b/tests/Components/Health/Checker/HealthChecker/ShopwareInstallerCheckerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\Health\Checker\HealthChecker;
+
+use Frosh\Tools\Components\Health\Checker\HealthChecker\ShopwareInstallerChecker;
+use Frosh\Tools\Components\Health\HealthCollection;
+use Frosh\Tools\Components\Health\SettingsResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ShopwareInstallerChecker::class)]
+class ShopwareInstallerCheckerTest extends TestCase
+{
+    public function testReportsErrorWhenInstallerIsInPublicDirectory(): void
+    {
+        $publicDir = $this->createPublicDir();
+        file_put_contents($publicDir . '/' . ShopwareInstallerChecker::FILE_NAME, '<?php // installer');
+
+        try {
+            $result = $this->collect($publicDir);
+
+            static::assertSame(SettingsResult::ERROR, $result->state);
+            static::assertSame(ShopwareInstallerChecker::ID, $result->id);
+            static::assertSame('Shopware installer', $result->getVars()['snippet']);
+            static::assertSame('present in public directory', $result->current);
+            static::assertSame('not present', $result->recommended);
+        } finally {
+            $this->removePublicDir($publicDir);
+        }
+    }
+
+    public function testReportsOkWhenInstallerIsAbsent(): void
+    {
+        $publicDir = $this->createPublicDir();
+
+        try {
+            $result = $this->collect($publicDir);
+
+            static::assertSame(SettingsResult::GREEN, $result->state);
+            static::assertSame(ShopwareInstallerChecker::ID, $result->id);
+            static::assertSame('not present', $result->current);
+        } finally {
+            $this->removePublicDir($publicDir);
+        }
+    }
+
+    public function testReportsOkWhenPublicDirectoryDoesNotExist(): void
+    {
+        $result = $this->collect(sys_get_temp_dir() . '/frosh-missing-public-' . uniqid('', true));
+
+        static::assertSame(SettingsResult::GREEN, $result->state);
+        static::assertSame('not present', $result->current);
+    }
+
+    private function collect(string $publicDir): SettingsResult
+    {
+        $collection = new HealthCollection();
+        (new ShopwareInstallerChecker($publicDir))->collect($collection);
+
+        static::assertCount(1, $collection);
+
+        /** @var SettingsResult $result */
+        $result = $collection->first();
+
+        return $result;
+    }
+
+    private function createPublicDir(): string
+    {
+        $publicDir = sys_get_temp_dir() . '/frosh-installer-health-' . uniqid('', true);
+        static::assertTrue(mkdir($publicDir, 0777, true));
+
+        return $publicDir;
+    }
+
+    private function removePublicDir(string $publicDir): void
+    {
+        $installer = $publicDir . '/' . ShopwareInstallerChecker::FILE_NAME;
+        if (is_file($installer)) {
+            unlink($installer);
+        }
+
+        if (is_dir($publicDir)) {
+            rmdir($publicDir);
+        }
+    }
+}

--- a/tests/Components/Security/Checker/ShopwareInstallerCheckerTest.php
+++ b/tests/Components/Security/Checker/ShopwareInstallerCheckerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\Security\Checker;
+
+use Frosh\Tools\Components\Security\Checker\ShopwareInstallerChecker;
+use Frosh\Tools\Components\Security\SecurityCollection;
+use Frosh\Tools\Components\Security\SecurityFinding;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ShopwareInstallerChecker::class)]
+class ShopwareInstallerCheckerTest extends TestCase
+{
+    public function testReportsCriticalWhenInstallerIsInPublicDirectory(): void
+    {
+        $publicDir = $this->createPublicDir();
+        file_put_contents($publicDir . '/' . ShopwareInstallerChecker::FILE_NAME, '<?php // installer');
+
+        try {
+            $finding = $this->collect($publicDir);
+
+            static::assertSame(ShopwareInstallerChecker::ID, $finding->id);
+            static::assertSame(SecurityFinding::SEVERITY_CRITICAL, $finding->severity);
+            static::assertSame(SecurityFinding::CATEGORY_CONFIGURATION, $finding->category);
+            static::assertSame('Shopware installer', $finding->title);
+            static::assertSame('present in public directory', $finding->current);
+            static::assertStringContainsString('shopware-installer.phar.php', $finding->recommended);
+        } finally {
+            $this->removePublicDir($publicDir);
+        }
+    }
+
+    public function testReportsOkWhenInstallerIsAbsent(): void
+    {
+        $publicDir = $this->createPublicDir();
+
+        try {
+            $finding = $this->collect($publicDir);
+
+            static::assertSame(SecurityFinding::SEVERITY_OK, $finding->severity);
+            static::assertSame(ShopwareInstallerChecker::ID, $finding->id);
+            static::assertSame('not present', $finding->current);
+        } finally {
+            $this->removePublicDir($publicDir);
+        }
+    }
+
+    private function collect(string $publicDir): SecurityFinding
+    {
+        $collection = new SecurityCollection();
+        (new ShopwareInstallerChecker($publicDir))->collect($collection);
+
+        static::assertCount(1, $collection);
+
+        /** @var SecurityFinding $finding */
+        $finding = $collection->first();
+
+        return $finding;
+    }
+
+    private function createPublicDir(): string
+    {
+        $publicDir = sys_get_temp_dir() . '/frosh-installer-security-' . uniqid('', true);
+        static::assertTrue(mkdir($publicDir, 0777, true));
+
+        return $publicDir;
+    }
+
+    private function removePublicDir(string $publicDir): void
+    {
+        $installer = $publicDir . '/' . ShopwareInstallerChecker::FILE_NAME;
+        if (is_file($installer)) {
+            unlink($installer);
+        }
+
+        if (is_dir($publicDir)) {
+            rmdir($publicDir);
+        }
+    }
+}

--- a/tests/Controller/HealthControllerTest.php
+++ b/tests/Controller/HealthControllerTest.php
@@ -40,6 +40,7 @@ class HealthControllerTest extends IntegrationTestCase
         static::assertContains('queue', $ids);
         static::assertContains('scheduled_task', $ids);
         static::assertContains('system-time', $ids);
+        static::assertContains('shopware-installer', $ids);
     }
 
     public function testPerformanceStatusReturnsValidResultList(): void

--- a/tests/Controller/SecurityControllerTest.php
+++ b/tests/Controller/SecurityControllerTest.php
@@ -38,12 +38,15 @@ class SecurityControllerTest extends IntegrationTestCase
         }
 
         static::assertIsArray($data['findings']);
+        $ids = [];
         foreach ($data['findings'] as $finding) {
             static::assertIsArray($finding);
             static::assertArrayHasKey('id', $finding);
             static::assertArrayHasKey('severity', $finding);
             static::assertArrayHasKey('category', $finding);
+            $ids[] = $finding['id'];
         }
+        static::assertContains('shopware-installer', $ids);
     }
 
     public function testSbomReturnsCycloneDxJsonAttachment(): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a check that reports an **error** when `public/shopware-installer.phar.php` is still present after installation.

The Shopware web installer is downloaded into the public directory for setup. Leaving it there is a security risk: anyone who can request that URL can start a reinstall and overwrite the shop.

## Changes

- New health checker `ShopwareInstallerChecker` reports `STATE_ERROR` when the installer file exists in `public/`, and OK when it does not.
- Matching security checker reports a **critical** configuration finding with the same check id (`shopware-installer`), so it can be skipped via `frosh_tools.checker.disabled_checks`.
- Inline System Status recommendation explaining why the file must be deleted.
- Health and security status API tests assert the new checker is registered.

## Testing

- Unit tests cover present / absent / missing-public-dir cases for both checkers.
- Controller integration tests confirm `shopware-installer` appears in `/health/status` and `/security/status`.
- All 11 related tests passed (`OK (11 tests, 240 assertions)`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30d6a740-aae5-411f-b15d-7383c026e650?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30d6a740-aae5-411f-b15d-7383c026e650&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

