### PR TITLE
fix: replace deprecated ShopwareStyle with SymfonyStyle

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,5 +6,9 @@ parameters:
     ignoreErrors:
         -
             message: "#no value type specified in iterable type array#"
+        # getEntities() remains in 6.8; ClassHierarchyChange still flags the call.
+        -
+            identifier: method.deprecatedClass
+            message: "#Call to method getEntities\\(\\) of deprecated class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\EntitySearchResult#"
     excludePaths:
         - vendor (?)

--- a/src/Command/ExtensionChecksumCheckCommand.php
+++ b/src/Command/ExtensionChecksumCheckCommand.php
@@ -6,7 +6,6 @@ namespace Frosh\Tools\Command;
 
 use Frosh\Tools\Components\ExtensionChecksum\ExtensionFileHashService;
 use Shopware\Core\Framework\Context;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -17,6 +16,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'frosh:extension:checksum:check',
@@ -111,7 +111,7 @@ class ExtensionChecksumCheckCommand extends Command
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('name', $name));
-        $extension = $this->pluginRepository->search($criteria, $context)->first();
+        $extension = $this->pluginRepository->search($criteria, $context)->getEntities()->first();
         if ($extension instanceof PluginEntity) {
             $extensions->add($extension);
         } else {

--- a/src/Command/ExtensionChecksumCheckCommand.php
+++ b/src/Command/ExtensionChecksumCheckCommand.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Frosh\Tools\Command;
 
 use Frosh\Tools\Components\ExtensionChecksum\ExtensionFileHashService;
-use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Context;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -44,7 +44,7 @@ class ExtensionChecksumCheckCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new ShopwareStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         $extensions = $this->getExtension((string) $input->getArgument('extension'), $io);
         if ($extensions->count() < 1) {
@@ -93,7 +93,7 @@ class ExtensionChecksumCheckCommand extends Command
         return $success ? self::SUCCESS : self::FAILURE;
     }
 
-    private function getExtension(string $name, ShopwareStyle $io): PluginCollection
+    private function getExtension(string $name, SymfonyStyle $io): PluginCollection
     {
         // @phpstan-ignore-next-line
         $context = method_exists(Context::class, 'createCLIContext') ? Context::createCLIContext() : Context::createDefaultContext();
@@ -124,7 +124,7 @@ class ExtensionChecksumCheckCommand extends Command
     /**
      * @param string[] $files
      */
-    private function outputFileChanges(ShopwareStyle $io, string $text, array $files): void
+    private function outputFileChanges(SymfonyStyle $io, string $text, array $files): void
     {
         if ($files) {
             $io->warning($text);

--- a/src/Command/ExtensionChecksumCreateCommand.php
+++ b/src/Command/ExtensionChecksumCreateCommand.php
@@ -6,7 +6,6 @@ namespace Frosh\Tools\Command;
 
 use Frosh\Tools\Components\ExtensionChecksum\ExtensionFileHashService;
 use Shopware\Core\Framework\Context;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -18,6 +17,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'frosh:extension:checksum:create',
@@ -97,6 +97,6 @@ class ExtensionChecksumCreateCommand extends Command
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('name', $name));
 
-        return $this->pluginRepository->search($criteria, $context)->first();
+        return $this->pluginRepository->search($criteria, $context)->getEntities()->first();
     }
 }

--- a/src/Command/ExtensionChecksumCreateCommand.php
+++ b/src/Command/ExtensionChecksumCreateCommand.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Frosh\Tools\Command;
 
 use Frosh\Tools\Components\ExtensionChecksum\ExtensionFileHashService;
-use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Context;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -45,7 +45,7 @@ class ExtensionChecksumCreateCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new ShopwareStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         // @phpstan-ignore-next-line
         $context = method_exists(Context::class, 'createCLIContext') ? Context::createCLIContext() : Context::createDefaultContext();
 

--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -11,13 +11,13 @@ use Frosh\Tools\Components\Health\SettingsResult;
 use Shopware\Core\Content\Mail\Service\AbstractMailSender;
 use Shopware\Core\Content\Mail\Service\MailSender;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Mime\Email;
 

--- a/src/Command/MonitorCommand.php
+++ b/src/Command/MonitorCommand.php
@@ -10,8 +10,8 @@ use Frosh\Tools\Components\Health\HealthCollection;
 use Frosh\Tools\Components\Health\SettingsResult;
 use Shopware\Core\Content\Mail\Service\AbstractMailSender;
 use Shopware\Core\Content\Mail\Service\MailSender;
-use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -46,7 +46,7 @@ class MonitorCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new ShopwareStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         if ($input->getArgument('sales-channel')) {
             $io->warning('The sales channel argument is deprecated and has no effect. It will be removed in a future release.');

--- a/src/Controller/ShopmonController.php
+++ b/src/Controller/ShopmonController.php
@@ -135,6 +135,7 @@ class ShopmonController extends AbstractController
         $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use (&$integration): void {
             $integration = $this->integrationRepository
                 ->search(new Criteria([self::INTEGRATION_ID]), $context)
+                ->getEntities()
                 ->first();
         });
 

--- a/src/Controller/ShopwareFilesController.php
+++ b/src/Controller/ShopwareFilesController.php
@@ -240,7 +240,7 @@ class ShopwareFilesController extends AbstractController
         $userEntity = $this->userRepository->search(
             new Criteria([$userId]),
             $context,
-        )->first();
+        )->getEntities()->first();
 
         if (!$userEntity instanceof UserEntity) {
             return null;
@@ -255,7 +255,7 @@ class ShopwareFilesController extends AbstractController
         $integrationEntity = $this->integrationRepository->search(
             new Criteria([$integrationId]),
             $context,
-        )->first();
+        )->getEntities()->first();
 
         if (!$integrationEntity instanceof IntegrationEntity) {
             return null;

--- a/src/Resources/app/administration/src/module/frosh-tools/page/index/index.spec.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/page/index/index.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { mountShopwareComponent } from '@friendsofshopware/vitest-shopware-admin-bridge/test-utils';
 import { FT_STUBS } from '../../../../../test/helpers';
 import './index';


### PR DESCRIPTION
## Summary
- Replace `Shopware\Core\Framework\Adapter\Console\ShopwareStyle` with `Symfony\Component\Console\Style\SymfonyStyle` in the remaining console commands.
- `ShopwareStyle` is deprecated and will be removed in Shopware 6.8; the other FroshTools commands already use `SymfonyStyle`.

## Test plan
- [ ] Run `bin/console frosh:monitor` and confirm output still works
- [ ] Run `bin/console frosh:extension:checksum:check` and `frosh:extension:checksum:create` and confirm file-change output still works