### PR TITLE
Feat: Add database diff (swdb.dev integration)

### DIFF
--- a/src/Command/DumpDatabaseIntrospection.php
+++ b/src/Command/DumpDatabaseIntrospection.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Command;
+
+use Frosh\Tools\Components\DatabaseDiff\DatabaseIntrospectionService;
+use Shopware\Core\Framework\Util\Json;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand('frosh:database:dump-introspection')]
+class DumpDatabaseIntrospection extends Command
+{
+    public function __construct(
+        #[Autowire('%kernel.project_dir%/var')]
+        private readonly string $envPath,
+        private readonly DatabaseIntrospectionService $databaseIntrospectionService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io     = new SymfonyStyle($input, $output);
+        $schema = $this->databaseIntrospectionService->getDatabaseSchema();
+        $path   = $this->envPath . '/swdb.schema.json';
+
+        $io->info(\sprintf('Dumping database introspection for Shopware %s...', $schema->version));
+
+        if (!\file_put_contents($path, Json::encode($schema), \LOCK_EX)) {
+            $io->error('Failed to write database schema.');
+
+            return Command::FAILURE;
+        }
+
+        $io->success(\sprintf('Database schema written to "%s".', $path));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Components/DatabaseDiff/DatabaseDiffService.php
+++ b/src/Components/DatabaseDiff/DatabaseDiffService.php
@@ -37,12 +37,49 @@ class DatabaseDiffService
             $json = \trim((string) $json);
             $data = Json::decodeToList($json);
 
-            // TODO: Adapt validation after endpoint is available.
-            //return \array_filter($data, 'is_string');
+            [$data, $errors] = $this->createVersions($data);
             return $data;
         } catch (\Throwable $error) {
             throw new \RuntimeException('Failed to load available versions', previous: $error);
         }
+    }
+
+    /**
+     * Separates valid from invalid entries in the version list response.
+     *
+     * @return array{0: array, 1: array}
+     */
+    private function createVersions(array $data): array
+    {
+        // TODO: Implement full validation definition.
+        $definition = (new DataValidationDefinition('frosh_tools.shopware_database_schema.version'))
+            ->add('version', new Assert\Type('string'))
+            ->add('slug', new Assert\Type('string'))
+            ->add('major', new Assert\Type('int'), new Assert\GreaterThanOrEqual(6))
+            ->add('minor', new Assert\Type('int'))
+            ->add('majorMinor', new Assert\Type('string'))
+            ->add('tableCount', new Assert\Type('integer'))
+            ->add('url', new Assert\Type('string'), new Assert\Url())
+            ->add('schemaUrl', new Assert\Type('string'), new Assert\Url());
+
+        $versions = [];
+        $errors   = [];
+
+        foreach ($data as $versionInfo) {
+            try {
+                $this->validator->validate($versionInfo, $definition);
+
+                $versions[$versionInfo['version']] = $versionInfo;
+            } catch (ConstraintViolationException $exception) {
+                $errors[$versionInfo['version']] = [
+                    'error'      => $exception->getMessage(),
+                    'violations' => (string) $exception->getViolations(),
+                    'data'       => $versionInfo,
+                ];
+            }
+        }
+
+        return [$versions, $errors];
     }
 
     /**
@@ -51,7 +88,9 @@ class DatabaseDiffService
     public function getDatabaseSchema(string $version): Schema
     {
         // TODO: Add resolution to the next higher/lower version available. Also, maybe handle the DEV version alias.
-        $version = \ltrim(Feature::normalizeName($version), 'v');
+        $version = \str_replace('RC', 'rc',
+            \ltrim(Feature::normalizeName($version), 'v')
+        );
         $url     = 'https://swdb.dev/api/schemas/%s.schema.json';
 
         try {

--- a/src/Components/DatabaseDiff/DatabaseDiffService.php
+++ b/src/Components/DatabaseDiff/DatabaseDiffService.php
@@ -146,10 +146,6 @@ class DatabaseDiffService
 
     public function createSchemaDiff(Schema $versionA, Schema $versionB): array
     {
-        if ($versionA->version === $versionB->version) {
-            return [];
-        }
-
         return \iterator_to_array($this->generateSchemaDiff($versionA, $versionB), false);
     }
 
@@ -194,8 +190,8 @@ class DatabaseDiffService
                 'type'   => 'tables',
                 'label'  => 'added',
                 'name'   => $tableB->table,
-                'valueA' => $tableB->table,
-                'valueB' => null,
+                'valueA' => null,
+                'valueB' => $tableB->table,
             ];
 
             yield from $this->generateTableDiff(null, $tableB);

--- a/src/Components/DatabaseDiff/DatabaseDiffService.php
+++ b/src/Components/DatabaseDiff/DatabaseDiffService.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff;
+
+use Frosh\Tools\Components\DatabaseDiff\Swdb\Schema;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Validation\DataValidationDefinition;
+use Shopware\Core\Framework\Validation\DataValidator;
+use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class DatabaseDiffService
+{
+    public function __construct(
+        #[Autowire(param: 'kernel.shopware_version')]
+        private readonly string $shopwareVersion,
+        private readonly HttpClientInterface $httpClient,
+        private readonly DataValidator $validator,
+    ) {
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function getAvailableVersions(): array
+    {
+        $url = 'https://swdb.dev/api/schemas.json';
+
+        try {
+            $json = $this->httpClient->request('GET', $url)
+                ->getContent(false);
+            $json = \trim((string) $json);
+            $data = Json::decodeToList($json);
+
+            // TODO: Adapt validation after endpoint is available.
+            //return \array_filter($data, 'is_string');
+            return $data;
+        } catch (\Throwable $error) {
+            throw new \RuntimeException('Failed to load available versions', previous: $error);
+        }
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function getDatabaseSchema(string $version): Schema
+    {
+        // TODO: Add resolution to the next higher/lower version available. Also, maybe handle the DEV version alias.
+        $version = \ltrim(Feature::normalizeName($version), 'v');
+        $url     = 'https://swdb.dev/api/schemas/%s.schema.json';
+
+        try {
+            $json = $this->httpClient->request('GET', \sprintf($url, $version))
+                ->getContent(false);
+            $json = \trim((string) $json);
+            $data = Json::decodeToList($json);
+
+            [$tables, $errors] = $this->createSchema($data);
+
+            // Create schema from valid data and attach errors as struct extension.
+            $schema = Schema::createFromData($tables, $version);
+            $schema->addArrayExtension('errors', $errors);
+            return $schema;
+        } catch (\Throwable $error) {
+            throw new \RuntimeException(\sprintf('Failed to load or create schema for version %s', $version),
+                previous: $error);
+        }
+    }
+
+    /**
+     * Separates valid from invalid entries in the schema response.
+     *
+     * @return array{0: array, 1: array}
+     */
+    private function createSchema(array $data): array
+    {
+        // TODO: Implement full validation definition.
+        $definition = $this->getValidationDefinition();
+
+        $tables = [];
+        $errors = [];
+
+        foreach ($data as $tableInfo) {
+            try {
+                $this->validator->validate($tableInfo, $definition);
+
+                $tables[$tableInfo['table']] = $tableInfo;
+            } catch (ConstraintViolationException $exception) {
+                $errors[$tableInfo['table']] = [
+                    'error'      => $exception->getMessage(),
+                    'violations' => (string) $exception->getViolations(),
+                    'data'       => $tableInfo,
+                ];
+            }
+        }
+
+        return [$tables, $errors];
+    }
+
+    public function createSchemaDiff(Schema $versionA, Schema $versionB): array
+    {
+        if ($versionA->version === $versionB->version) {
+            return [];
+        }
+
+        return \iterator_to_array($this->generateSchemaDiff($versionA, $versionB), false);
+    }
+
+    private function generateSchemaDiff(Schema $versionA, Schema $versionB): \Generator
+    {
+        foreach ($versionA->tables as $tableA) {
+            foreach ($versionB->tables as $tableB) {
+                if ($tableA->table !== $tableB->table) {
+                    continue 1;
+                }
+
+                yield from $this->generateTableDiff($tableA, $tableB);
+
+                continue 2;
+            }
+
+            // Table removed.
+            yield [
+                'table'  => $tableA->table,
+                'type'   => 'tables',
+                'label'  => 'removed',
+                'name'   => $tableA->table,
+                'valueA' => $tableA->table,
+                'valueB' => null,
+            ];
+
+            yield from $this->generateTableDiff($tableA, null);
+        }
+
+        foreach ($versionB->tables as $tableB) {
+            foreach ($versionA->tables as $tableA) {
+                if ($tableB->table !== $tableA->table) {
+                    continue 1;
+                }
+
+                continue 2;
+            }
+
+            // Table added.
+            yield [
+                'table'  => $tableB->table,
+                'type'   => 'tables',
+                'label'  => 'added',
+                'name'   => $tableB->table,
+                'valueA' => $tableB->table,
+                'valueB' => null,
+            ];
+
+            yield from $this->generateTableDiff(null, $tableB);
+        }
+    }
+
+    private function generateTableDiff(?Swdb\Table $tableA, ?Swdb\Table $tableB): \Generator
+    {
+        if (null === $tableA && null === $tableB) {
+            throw new \InvalidArgumentException('At least one table is required to generate a diff');
+        }
+
+        $tableA ??= new Swdb\Table($tableB?->table ?? '');
+        $tableB ??= new Swdb\Table($tableA?->table ?? '');
+
+        $properties = ['fields', 'relationsToTable', 'relationsFromTable', 'indexes'];
+
+        // Found the matching table, check members...
+        foreach ($properties as $property) {
+            // Among each list of members, check for differences.
+            foreach ($tableA->{$property} as $memberA) {
+                foreach ($tableB->{$property} as $memberB) {
+                    if ($memberA->key() !== $memberB->key()) {
+                        continue 1;
+                    }
+
+                    // Member modified.
+                    if ($memberA->compare($memberB)) {
+                        yield [
+                            'table'  => $memberA->table,
+                            'type'   => $memberA->type(),
+                            'label'  => 'modified',
+                            'name'   => $memberA->key(),
+                            'valueA' => $memberA->label(),
+                            'valueB' => $memberB->label(),
+                        ];
+                    }
+
+                    // Found; no need to continue the search.
+                    continue 2;
+                }
+
+                // Not found, column removed.
+                yield [
+                    'table'  => $memberA->table,
+                    'type'   => $memberA->type(),
+                    'label'  => 'removed',
+                    'name'   => $memberA->key(),
+                    'valueA' => $memberA->label(),
+                    'valueB' => null,
+                ];
+            }
+
+            // Search for added fields.
+            foreach ($tableB->{$property} as $memberB) {
+                foreach ($tableA->{$property} as $memberA) {
+                    if ($memberB->key() !== $memberA->key()) {
+                        continue 1;
+                    }
+
+                    // Found.
+                    continue 2;
+                }
+
+                // Not found, column added.
+                yield [
+                    'table'  => $memberB->table,
+                    'type'   => $memberB->type(),
+                    'label'  => 'added',
+                    'name'   => $memberB->key(),
+                    'valueA' => null,
+                    'valueB' => $memberB->label(),
+                ];
+            }
+        }
+    }
+
+    /**
+     * TODO: Add constraints.
+     */
+    private function getValidationDefinition(): DataValidationDefinition
+    {
+        return (new DataValidationDefinition('frosh_tools.shopware_database_schema.table'))
+            ->addList('fields',
+                (new DataValidationDefinition('frosh_tools.shopware_database_schema.table.fields'))
+                    ->add('Default')
+                    ->add('Extra')
+                    ->add('Field')
+                    ->add('Key')
+                    ->add('Null')
+                    ->add('Type')
+            )
+            ->addList('indexes',
+                (new DataValidationDefinition('frosh_tools.shopware_database_schema.table.indexes'))
+                    ->add('Columns')
+                    ->add('Index')
+                    ->add('Index')
+            )
+            ->addList('relationsFromTable',
+                (new DataValidationDefinition('frosh_tools.shopware_database_schema.table.relations_from'))
+                    ->add('foreignField')
+                    ->add('foreignSchema')
+                    ->add('foreignTable')
+                    ->add('localField')
+            )
+            ->addList('relationsToTable',
+                (new DataValidationDefinition('frosh_tools.shopware_database_schema.table.relations_to'))
+                    ->add('foreignField')
+                    ->add('foreignSchema')
+                    ->add('foreignTable')
+                    ->add('localField')
+            )
+            ->add('table', new Assert\NotBlank(), new Assert\Type('string'))
+        ;
+    }
+}

--- a/src/Components/DatabaseDiff/DatabaseDiffService.php
+++ b/src/Components/DatabaseDiff/DatabaseDiffService.php
@@ -17,8 +17,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class DatabaseDiffService
 {
     public function __construct(
-        #[Autowire(param: 'kernel.shopware_version')]
-        private readonly string $shopwareVersion,
         private readonly HttpClientInterface $httpClient,
         private readonly DataValidator $validator,
     ) {
@@ -231,8 +229,8 @@ class DatabaseDiffService
                             'type'   => $memberA->type(),
                             'label'  => 'modified',
                             'name'   => $memberA->key(),
-                            'valueA' => $memberA->label(),
-                            'valueB' => $memberB->label(),
+                            'valueA' => $memberA->value(),
+                            'valueB' => $memberB->value(),
                         ];
                     }
 
@@ -246,7 +244,7 @@ class DatabaseDiffService
                     'type'   => $memberA->type(),
                     'label'  => 'removed',
                     'name'   => $memberA->key(),
-                    'valueA' => $memberA->label(),
+                    'valueA' => $memberA->value(),
                     'valueB' => null,
                 ];
             }
@@ -269,7 +267,7 @@ class DatabaseDiffService
                     'label'  => 'added',
                     'name'   => $memberB->key(),
                     'valueA' => null,
-                    'valueB' => $memberB->label(),
+                    'valueB' => $memberB->value(),
                 ];
             }
         }

--- a/src/Components/DatabaseDiff/DatabaseDiffService.php
+++ b/src/Components/DatabaseDiff/DatabaseDiffService.php
@@ -88,9 +88,7 @@ class DatabaseDiffService
     public function getDatabaseSchema(string $version): Schema
     {
         // TODO: Add resolution to the next higher/lower version available. Also, maybe handle the DEV version alias.
-        $version = \str_replace('RC', 'rc',
-            \ltrim(Feature::normalizeName($version), 'v')
-        );
+        $version = $this->parseVersionSlug($version);
         $url     = 'https://swdb.dev/api/schemas/%s.schema.json';
 
         try {
@@ -109,6 +107,13 @@ class DatabaseDiffService
             throw new \RuntimeException(\sprintf('Failed to load or create schema for version %s', $version),
                 previous: $error);
         }
+    }
+
+    public function parseVersionSlug(string $version): string
+    {
+        return \str_replace('RC', 'rc',
+            \ltrim(Feature::normalizeName($version), 'v')
+        );
     }
 
     /**

--- a/src/Components/DatabaseDiff/DatabaseIntrospectionService.php
+++ b/src/Components/DatabaseDiff/DatabaseIntrospectionService.php
@@ -8,21 +8,16 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
 use Doctrine\DBAL\Schema as Dbal;
 use Doctrine\DBAL\Types\DateTimeType;
-use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\TypeRegistry;
 use Frosh\Tools\Components\DatabaseDiff\Swdb\Schema;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class DatabaseIntrospectionService
 {
-    private readonly TypeRegistry $typeRegistry;
-
     public function __construct(
         #[Autowire(param: 'kernel.shopware_version')]
         private readonly string $shopwareVersion,
         private readonly Connection $connection,
     ) {
-        $this->typeRegistry = Type::getTypeRegistry();
     }
 
     public function getDatabaseSchema(): Schema
@@ -50,15 +45,23 @@ class DatabaseIntrospectionService
             $result[$table->getName()] = $this->introspectTable($table);
         }
 
-        return \array_values($result);
+        return $result;
     }
 
     private function introspectTable(Dbal\Table $table): Swdb\Table
     {
         [$relationsFromTable, $relationsToTable] = $this->introspectTableRelations($table);
 
-        $fields  = \array_filter(\array_map(fn ($column) => $this->introspectTableField($table, $column), $table->getColumns()));
-        $indexes = \array_filter(\array_map(fn ($index)  => $this->introspectIndex($table, $index),       $table->getIndexes()));
+        $fields  = \array_filter(
+            \array_map(fn ($column) => $this->introspectTableField($table, $column),
+                $table->getColumns()
+            )
+        );
+        $indexes = \array_filter(
+            \array_map(fn ($index)  => $this->introspectIndex($table, $index),
+                $table->getIndexes()
+            )
+        );
 
         return new Swdb\Table(
             $table->getName(),
@@ -72,6 +75,7 @@ class DatabaseIntrospectionService
     private function introspectTableField(Dbal\Table $table, Dbal\Column $column): ?Swdb\TableField
     {
         $type = $column->getType();
+
         $typeDeclaration = $type->getSQLDeclaration([
             'length'    => $column->getLength(),
             'fixed'     => $column->getFixed(),
@@ -79,6 +83,7 @@ class DatabaseIntrospectionService
             'precision' => $column->getPrecision(),
             'unsigned'  => $column->getUnsigned(),
         ], $this->connection->getDatabasePlatform());
+
         if ($type instanceof DateTimeType) {
             $typeDeclaration = \sprintf('%s(%d)', $typeDeclaration, $column->getLength());
         }
@@ -95,6 +100,7 @@ class DatabaseIntrospectionService
             ])),
         );
         $tableField->table = $table->getName();
+
         return $tableField;
     }
 
@@ -146,7 +152,7 @@ SQL,
                 'table' => $table->getName(),
             ],
         );
-        $resultTo = $this->connection->executeQuery(
+        $resultTo   = $this->connection->executeQuery(
             <<<'SQL'
 -- mysql-json-schema relations to table
 SELECT  TABLE_SCHEMA            as foreignSchema,
@@ -168,8 +174,12 @@ SQL,
         );
 
         return [
-            \array_map(fn ($data) => $this->introspectTableRelationFrom($table, $data), $resultFrom->fetchAllAssociative()),
-            \array_map(fn ($data) => $this->introspectTableRelationTo($table, $data), $resultTo->fetchAllAssociative()),
+            \array_map(fn ($data) => $this->introspectTableRelationFrom($table, $data),
+                $resultFrom->fetchAllAssociative()
+            ),
+            \array_map(fn ($data) => $this->introspectTableRelationTo($table, $data),
+                $resultTo->fetchAllAssociative()
+            ),
         ];
     }
 
@@ -186,6 +196,7 @@ SQL,
             $index->isUnique(),
         );
         $tableIndex->table = $table->getName();
+
         return $tableIndex;
     }
 
@@ -193,6 +204,7 @@ SQL,
     {
         $tableRelation = Swdb\TableRelation::createFromData($data);
         $tableRelation->table = $table->getName();
+
         return $tableRelation;
     }
 
@@ -200,6 +212,7 @@ SQL,
     {
         $tableRelation = Swdb\InverseTableRelation::createFromData($data);
         $tableRelation->table = $table->getName();
+
         return $tableRelation;
     }
 }

--- a/src/Components/DatabaseDiff/DatabaseIntrospectionService.php
+++ b/src/Components/DatabaseDiff/DatabaseIntrospectionService.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DbalException;
+use Doctrine\DBAL\Schema as Dbal;
+use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
+use Frosh\Tools\Components\DatabaseDiff\Swdb\Schema;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+class DatabaseIntrospectionService
+{
+    private readonly TypeRegistry $typeRegistry;
+
+    public function __construct(
+        #[Autowire(param: 'kernel.shopware_version')]
+        private readonly string $shopwareVersion,
+        private readonly Connection $connection,
+    ) {
+        $this->typeRegistry = Type::getTypeRegistry();
+    }
+
+    public function getDatabaseSchema(): Schema
+    {
+        return new Schema($this->shopwareVersion, $this->introspectSchema());
+    }
+
+    /**
+     * @return array<string, Swdb\Table>
+     */
+    private function introspectSchema(): array
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        try {
+            $tables = \method_exists($schemaManager, 'introspectTables')
+                ? $schemaManager->introspectTables()
+                : $schemaManager->listTables();
+        } catch (DbalException $e) {
+            throw new \RuntimeException('DBAL introspection error', previous: $e);
+        }
+        $result = [];
+
+        foreach ($tables as $table) {
+            $result[$table->getName()] = $this->introspectTable($table);
+        }
+
+        return \array_values($result);
+    }
+
+    private function introspectTable(Dbal\Table $table): Swdb\Table
+    {
+        [$relationsFromTable, $relationsToTable] = $this->introspectTableRelations($table);
+
+        $fields  = \array_filter(\array_map(fn ($column) => $this->introspectTableField($table, $column), $table->getColumns()));
+        $indexes = \array_filter(\array_map(fn ($index)  => $this->introspectIndex($table, $index),       $table->getIndexes()));
+
+        return new Swdb\Table(
+            $table->getName(),
+            $fields,
+            $relationsFromTable,
+            $relationsToTable,
+            $indexes,
+        );
+    }
+
+    private function introspectTableField(Dbal\Table $table, Dbal\Column $column): ?Swdb\TableField
+    {
+        $type = $column->getType();
+        $typeDeclaration = $type->getSQLDeclaration([
+            'length'    => $column->getLength(),
+            'fixed'     => $column->getFixed(),
+            'scale'     => $column->getScale(),
+            'precision' => $column->getPrecision(),
+            'unsigned'  => $column->getUnsigned(),
+        ], $this->connection->getDatabasePlatform());
+        if ($type instanceof DateTimeType) {
+            $typeDeclaration = \sprintf('%s(%d)', $typeDeclaration, $column->getLength());
+        }
+
+        $tableField = new Swdb\TableField(
+            $column->getName(),
+            \strtolower($typeDeclaration),
+            !$column->getNotnull(),
+            $this->introspectTableFieldKey($table, $column),
+            $column->getDefault(),
+            \implode(' ', \array_filter([
+                $column->getAutoincrement() ? 'auto_increment' : '',
+                $column->getColumnDefinition() ?? '',
+            ])),
+        );
+        $tableField->table = $table->getName();
+        return $tableField;
+    }
+
+    private function introspectTableFieldKey(Dbal\Table $table, Dbal\Column $column): string
+    {
+        foreach ($table->getIndexes() as $index) {
+            if (!\in_array($column->getName(), $index->getColumns(), true)) {
+                continue;
+            }
+
+            if ($index->isPrimary()) {
+                return 'PRI';
+            }
+
+            if ($index->isUnique()) {
+                return 'UNI';
+            }
+
+            return 'MUL';
+        }
+
+        return '';
+    }
+
+    /**
+     * @see https://github.com/llorentegerman/mysql-json-schema/blob/master/src/mysql.js
+     *
+     * @return array{0: array, 1: array}
+     */
+    private function introspectTableRelations(Dbal\Table $table): array
+    {
+        $resultFrom = $this->connection->executeQuery(
+            <<<'SQL'
+-- mysql-json-schema relations from table
+SELECT  TABLE_SCHEMA            as localSchema,
+        TABLE_NAME              as localTable,
+        COLUMN_NAME             as localField,
+        REFERENCED_TABLE_SCHEMA as foreignSchema,
+        REFERENCED_TABLE_NAME   as foreignTable,
+        REFERENCED_COLUMN_NAME  as foreignField
+FROM
+    INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+WHERE
+    TABLE_SCHEMA = SCHEMA()
+  AND REFERENCED_TABLE_NAME IS NOT NULL
+  and (TABLE_NAME = :table);
+SQL,
+            [
+                'table' => $table->getName(),
+            ],
+        );
+        $resultTo = $this->connection->executeQuery(
+            <<<'SQL'
+-- mysql-json-schema relations to table
+SELECT  TABLE_SCHEMA            as foreignSchema,
+        TABLE_NAME              as foreignTable,
+        COLUMN_NAME             as foreignField,
+        REFERENCED_TABLE_SCHEMA as localSchema,
+        REFERENCED_TABLE_NAME   as localTable,
+        REFERENCED_COLUMN_NAME  as localField
+FROM
+    INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+WHERE
+    TABLE_SCHEMA = SCHEMA()
+  AND REFERENCED_TABLE_NAME IS NOT NULL
+  and (REFERENCED_TABLE_NAME = :table);
+SQL,
+            [
+                'table' => $table->getName(),
+            ],
+        );
+
+        return [
+            \array_map(fn ($data) => $this->introspectTableRelationFrom($table, $data), $resultFrom->fetchAllAssociative()),
+            \array_map(fn ($data) => $this->introspectTableRelationTo($table, $data), $resultTo->fetchAllAssociative()),
+        ];
+    }
+
+    private function introspectIndex(Dbal\Table $table, Dbal\Index $index): ?Swdb\TableIndex
+    {
+        // Exclude automatic indexes.
+        if (\str_starts_with($index->getName(), 'IDX_')) {
+            return null;
+        }
+
+        $tableIndex = new Swdb\TableIndex(
+            \implode(',', $index->getColumns()),
+            $index->getName(),
+            $index->isUnique(),
+        );
+        $tableIndex->table = $table->getName();
+        return $tableIndex;
+    }
+
+    private function introspectTableRelationFrom(Dbal\Table $table, array $data): Swdb\TableRelation
+    {
+        $tableRelation = Swdb\TableRelation::createFromData($data);
+        $tableRelation->table = $table->getName();
+        return $tableRelation;
+    }
+
+    private function introspectTableRelationTo(Dbal\Table $table, array $data): Swdb\InverseTableRelation
+    {
+        $tableRelation = Swdb\InverseTableRelation::createFromData($data);
+        $tableRelation->table = $table->getName();
+        return $tableRelation;
+    }
+}

--- a/src/Components/DatabaseDiff/DatabaseIntrospectionService.php
+++ b/src/Components/DatabaseDiff/DatabaseIntrospectionService.php
@@ -6,18 +6,23 @@ namespace Frosh\Tools\Components\DatabaseDiff;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception as DbalException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema as Dbal;
-use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\IntegerType;
+use Frosh\Tools\Components\DatabaseDiff\Dbal\CustomMySQLSchemaManager;
 use Frosh\Tools\Components\DatabaseDiff\Swdb\Schema;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class DatabaseIntrospectionService
 {
+    private readonly AbstractPlatform $platform;
+
     public function __construct(
         #[Autowire(param: 'kernel.shopware_version')]
         private readonly string $shopwareVersion,
         private readonly Connection $connection,
     ) {
+        $this->platform = $this->connection->getDatabasePlatform();
     }
 
     public function getDatabaseSchema(): Schema
@@ -30,7 +35,7 @@ class DatabaseIntrospectionService
      */
     private function introspectSchema(): array
     {
-        $schemaManager = $this->connection->createSchemaManager();
+        $schemaManager = new CustomMySQlSchemaManager($this->connection, $this->platform);
 
         try {
             $tables = \method_exists($schemaManager, 'introspectTables')
@@ -75,54 +80,32 @@ class DatabaseIntrospectionService
     private function introspectTableField(Dbal\Table $table, Dbal\Column $column): ?Swdb\TableField
     {
         $type = $column->getType();
+        $raw  = $column->getPlatformOption('raw');
+        $decl = \strtolower(
+            $type->getSQLDeclaration([
+                'unsigned'      => $column->getUnsigned(),
+                'autoincrement' => $column->getAutoincrement(),
+                ...$raw,
+            ], $this->platform)
+        );
 
-        $typeDeclaration = $type->getSQLDeclaration([
-            'length'    => $column->getLength(),
-            'fixed'     => $column->getFixed(),
-            'scale'     => $column->getScale(),
-            'precision' => $column->getPrecision(),
-            'unsigned'  => $column->getUnsigned(),
-        ], $this->connection->getDatabasePlatform());
-
-        if ($type instanceof DateTimeType) {
-            $typeDeclaration = \sprintf('%s(%d)', $typeDeclaration, $column->getLength());
+        // Integer types got removed at some point, so we resort to the DBAL declaration.
+        // Note: Depends on MySQL/MariaDB version.
+        if ($type instanceof IntegerType) {
+            $raw['type'] = $decl;
         }
 
         $tableField = new Swdb\TableField(
             $column->getName(),
-            \strtolower($typeDeclaration),
+            $raw['type'],
             !$column->getNotnull(),
-            $this->introspectTableFieldKey($table, $column),
+            $raw['key'],
             $column->getDefault(),
-            \implode(' ', \array_filter([
-                $column->getAutoincrement() ? 'auto_increment' : '',
-                $column->getColumnDefinition() ?? '',
-            ])),
+            $raw['extra'],
         );
         $tableField->table = $table->getName();
 
         return $tableField;
-    }
-
-    private function introspectTableFieldKey(Dbal\Table $table, Dbal\Column $column): string
-    {
-        foreach ($table->getIndexes() as $index) {
-            if (!\in_array($column->getName(), $index->getColumns(), true)) {
-                continue;
-            }
-
-            if ($index->isPrimary()) {
-                return 'PRI';
-            }
-
-            if ($index->isUnique()) {
-                return 'UNI';
-            }
-
-            return 'MUL';
-        }
-
-        return '';
     }
 
     /**

--- a/src/Components/DatabaseDiff/Dbal/CustomMySQLSchemaManager.php
+++ b/src/Components/DatabaseDiff/Dbal/CustomMySQLSchemaManager.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff\Dbal;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\MySQLSchemaManager;
+
+class CustomMySQLSchemaManager extends MySQLSchemaManager
+{
+    public function __construct(
+        protected Connection $connection,
+        protected AbstractPlatform $platform
+    ) {
+        parent::__construct($connection, $platform);
+    }
+
+    protected function _getPortableTableColumnDefinition($tableColumn): Column
+    {
+        $column      = parent::_getPortableTableColumnDefinition($tableColumn);
+        $tableColumn = \array_change_key_case($tableColumn, \CASE_LOWER);
+
+        $column->setPlatformOptions([
+            'raw'  => $tableColumn,
+        ]);
+
+        return $column;
+    }
+}

--- a/src/Components/DatabaseDiff/Swdb/InverseTableRelation.php
+++ b/src/Components/DatabaseDiff/Swdb/InverseTableRelation.php
@@ -19,7 +19,7 @@ class InverseTableRelation extends TableRelation
         return \sprintf('%s.%s', $this->foreignTable, $this->foreignField);
     }
 
-    public function label(): string
+    public function value(): string
     {
         return "foreign key `{$this->foreignTable}.{$this->foreignField}` references `{$this->table}.{$this->localField}`";
     }

--- a/src/Components/DatabaseDiff/Swdb/InverseTableRelation.php
+++ b/src/Components/DatabaseDiff/Swdb/InverseTableRelation.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff\Swdb;
+
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+#[Exclude]
+class InverseTableRelation extends TableRelation
+{
+    public function type(): string
+    {
+        return 'relationsToTable';
+    }
+
+    public function key(): string
+    {
+        return \sprintf('%s.%s', $this->foreignTable, $this->foreignField);
+    }
+
+    public function label(): string
+    {
+        return "foreign key `{$this->foreignTable}.{$this->foreignField}` references `{$this->table}.{$this->localField}`";
+    }
+}

--- a/src/Components/DatabaseDiff/Swdb/Schema.php
+++ b/src/Components/DatabaseDiff/Swdb/Schema.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff\Swdb;
+
+use Shopware\Core\Framework\Struct\Struct;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+#[Exclude]
+class Schema extends Struct
+{
+    /**
+     * @param string $version
+     * @param array<Table> $tables
+     */
+    public function __construct(
+        public readonly string $version,
+        public readonly array  $tables = [],
+    ) {
+    }
+
+    public static function createFromData(array $data, string $version): static
+    {
+        return new static(
+            $version,
+            \array_map(Table::createFromData(...), $data),
+        );
+    }
+}

--- a/src/Components/DatabaseDiff/Swdb/Table.php
+++ b/src/Components/DatabaseDiff/Swdb/Table.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff\Swdb;
+
+use Shopware\Core\Framework\Struct\Struct;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+#[Exclude]
+class Table extends Struct
+{
+    /**
+     * @param array<TableField>    $fields
+     * @param array<TableRelation> $relationsFromTable
+     * @param array<TableRelation> $relationsToTable
+     * @param array<TableIndex>    $indexes
+     */
+    public function __construct(
+        public readonly string $table,
+        public readonly array  $fields             = [],
+        public readonly array  $relationsFromTable = [],
+        public readonly array  $relationsToTable   = [],
+        public readonly array  $indexes            = [],
+    ) {
+    }
+
+    public static function createFromData(array $data): static
+    {
+        $table = new static(
+            $data['table'],
+            \array_map(TableField::createFromData(...), $data['fields']),
+            \array_map(TableRelation::createFromData(...), $data['relationsFromTable']),
+            \array_map(InverseTableRelation::createFromData(...), $data['relationsToTable']),
+            \array_map(TableIndex::createFromData(...), $data['indexes']),
+        );
+
+        $vars = $table->getVars();
+        foreach ($vars as $list) {
+            if (!\is_array($list)) {
+                continue;
+            }
+
+            foreach ($list as $entry) {
+                /**
+                 * @var TableField|TableRelation|InverseTableRelation|TableIndex $entry
+                 */
+                $entry->table = $table->table;
+            }
+        }
+
+        return $table;
+    }
+}

--- a/src/Components/DatabaseDiff/Swdb/TableField.php
+++ b/src/Components/DatabaseDiff/Swdb/TableField.php
@@ -51,16 +51,45 @@ class TableField extends Struct implements TableMemberInterface
     {
         if (
             $this->field !== $member->field
-            || $this->type !== $member->type
+            || $this->compareType($this->type, $member->type)
             || $this->null !== $member->null
             || $this->key !== $member->key
-            || $this->default !== $member->default
+            || $this->compareDefault($this->default, $member->default)
             || $this->extra !== $member->extra
         ) {
             return true;
         }
 
         return false;
+    }
+
+    public static function compareType(string $typeA, string $typeB, bool $considerLength = false): bool
+    {
+        $typeA   = \strtok($typeA, '(), ');
+        $lengthA = \strtok('(), ');
+        $typeB   = \strtok($typeB, '(), ');
+        $lengthB = \strtok('(), ');
+
+        return ($typeA !== $typeB)
+            && (!$considerLength || $lengthA !== $lengthB);
+    }
+
+    public static function compareDefault(?string $defaultA, ?string $defaultB): bool
+    {
+        $formatBinary = static fn ($default) => match (\substr($default, 0, 2)) {
+            '0x'    => \strtolower(\substr($default, 2)),
+            "x'"    => \strtok($default, "x''"),
+            default => $default,
+        };
+
+        if (\is_string($defaultA)) {
+            $defaultA = $formatBinary($defaultA);
+        }
+        if (\is_string($defaultB)) {
+            $defaultB = $formatBinary($defaultB);
+        }
+
+        return $defaultA !== $defaultB;
     }
 
     public static function createFromData(array $data): static

--- a/src/Components/DatabaseDiff/Swdb/TableField.php
+++ b/src/Components/DatabaseDiff/Swdb/TableField.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Frosh\Tools\Components\DatabaseDiff\Swdb;
 
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Util\Json;
 use Symfony\Component\DependencyInjection\Attribute\Exclude;
@@ -52,11 +51,11 @@ class TableField extends Struct implements TableMemberInterface
     {
         if (
             $this->field !== $member->field
-            && $this->type !== $member->type
-            && $this->null !== $member->null
-            //&& $this->key !== $member->key
-            && $this->default !== $member->default
-            && $this->extra !== $member->extra
+            || $this->type !== $member->type
+            || $this->null !== $member->null
+            || $this->key !== $member->key
+            || $this->default !== $member->default
+            || $this->extra !== $member->extra
         ) {
             return true;
         }

--- a/src/Components/DatabaseDiff/Swdb/TableField.php
+++ b/src/Components/DatabaseDiff/Swdb/TableField.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff\Swdb;
+
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Core\Framework\Util\Json;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+#[Exclude]
+class TableField extends Struct implements TableMemberInterface
+{
+    public string $table;
+
+    public function __construct(
+        public readonly string  $field,
+        public readonly string  $type,
+        public readonly bool    $null,
+        public readonly string  $key,
+        public readonly ?string $default,
+        public readonly string  $extra,
+    ) {
+    }
+
+    public function type(): string
+    {
+        return 'fields';
+    }
+
+    public function key(): string
+    {
+        return \sprintf('%s.%s', $this->table, $this->field);
+    }
+
+    public function label(): string
+    {
+        return \implode(' ', [
+            $this->type,
+            $this->null ? 'null' : 'not null',
+            'default ' . Json::encode($this->default),
+            $this->extra,
+            $this->key ? "/* key={$this->key} */" : '',
+        ]);
+    }
+
+    /**
+     * @param static $member
+     */
+    public function compare($member): bool
+    {
+        if (
+            $this->field !== $member->field
+            && $this->type !== $member->type
+            && $this->null !== $member->null
+            //&& $this->key !== $member->key
+            && $this->default !== $member->default
+            && $this->extra !== $member->extra
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function createFromData(array $data): static
+    {
+        return new static(
+            $data['Field'],
+            $data['Type'],
+            $data['Null'],
+            $data['Key'],
+            $data['Default'],
+            $data['Extra'],
+        );
+    }
+}

--- a/src/Components/DatabaseDiff/Swdb/TableField.php
+++ b/src/Components/DatabaseDiff/Swdb/TableField.php
@@ -34,15 +34,15 @@ class TableField extends Struct implements TableMemberInterface
         return \sprintf('%s.%s', $this->table, $this->field);
     }
 
-    public function label(): string
+    public function value(): string
     {
-        return \implode(' ', [
+        return \implode(' ', \array_filter([
             $this->type,
             $this->null ? 'null' : 'not null',
             'default ' . Json::encode($this->default),
             $this->extra,
             $this->key ? "/* key={$this->key} */" : '',
-        ]);
+        ]));
     }
 
     /**

--- a/src/Components/DatabaseDiff/Swdb/TableIndex.php
+++ b/src/Components/DatabaseDiff/Swdb/TableIndex.php
@@ -29,13 +29,13 @@ class TableIndex extends Struct implements tableMemberInterface
         return $this->index;
     }
 
-    public function label(): string
+    public function value(): string
     {
-        return \implode(' ', [
+        return \implode(' ', \array_filter([
             "/* index={$this->index} */",
             "{$this->table}($this->columns)",
             $this->unique ? 'unique' : '',
-        ]);
+        ]));
     }
 
     public function compare($member): bool

--- a/src/Components/DatabaseDiff/Swdb/TableIndex.php
+++ b/src/Components/DatabaseDiff/Swdb/TableIndex.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff\Swdb;
+
+use Shopware\Core\Framework\Struct\Struct;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+#[Exclude]
+class TableIndex extends Struct implements tableMemberInterface
+{
+    public string $table;
+
+    public function __construct(
+        public readonly string $columns,
+        public readonly string $index,
+        public readonly bool $unique,
+    ) {
+    }
+
+    public function type(): string
+    {
+        return 'indexes';
+    }
+
+    public function key(): string
+    {
+        return $this->index;
+    }
+
+    public function label(): string
+    {
+        return \implode(' ', [
+            "/* index={$this->index} */",
+            "{$this->table}($this->columns)",
+            $this->unique ? 'unique' : '',
+        ]);
+    }
+
+    public function compare($member): bool
+    {
+        return $this != $member;
+    }
+
+    public static function createFromData(array $data): static
+    {
+        return new static(
+            $data['Columns'],
+            $data['Index'],
+            (bool)$data['Unique'],
+        );
+    }
+}

--- a/src/Components/DatabaseDiff/Swdb/TableMemberInterface.php
+++ b/src/Components/DatabaseDiff/Swdb/TableMemberInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff\Swdb;
+
+/**
+ * @property string $table
+ */
+interface TableMemberInterface
+{
+    public function type(): string;
+
+    public function key(): string;
+
+    public function label(): string;
+
+    /**
+     * @param static $member
+     */
+    public function compare($member): bool;
+}

--- a/src/Components/DatabaseDiff/Swdb/TableMemberInterface.php
+++ b/src/Components/DatabaseDiff/Swdb/TableMemberInterface.php
@@ -13,7 +13,7 @@ interface TableMemberInterface
 
     public function key(): string;
 
-    public function label(): string;
+    public function value(): string;
 
     /**
      * @param static $member

--- a/src/Components/DatabaseDiff/Swdb/TableRelation.php
+++ b/src/Components/DatabaseDiff/Swdb/TableRelation.php
@@ -30,7 +30,7 @@ class TableRelation extends Struct implements TableMemberInterface
         return \sprintf('%s.%s', $this->table, $this->localField);
     }
 
-    public function label(): string
+    public function value(): string
     {
         return "foreign key `{$this->table}.{$this->localField}` references `{$this->foreignTable}.{$this->foreignField}`";
     }

--- a/src/Components/DatabaseDiff/Swdb/TableRelation.php
+++ b/src/Components/DatabaseDiff/Swdb/TableRelation.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Components\DatabaseDiff\Swdb;
+
+use Shopware\Core\Framework\Struct\Struct;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+#[Exclude]
+class TableRelation extends Struct implements TableMemberInterface
+{
+    public string $table;
+
+    public function __construct(
+        public readonly string $localField,
+        public readonly string $foreignSchema,
+        public readonly string $foreignTable,
+        public readonly string $foreignField,
+    ) {
+    }
+
+    public function type(): string
+    {
+        return 'relationsFromTable';
+    }
+
+    public function key(): string
+    {
+        return \sprintf('%s.%s', $this->table, $this->localField);
+    }
+
+    public function label(): string
+    {
+        return "foreign key `{$this->table}.{$this->localField}` references `{$this->foreignTable}.{$this->foreignField}`";
+    }
+
+    public function compare($member): bool
+    {
+        return $this != $member;
+    }
+
+    public static function createFromData(array $data): static
+    {
+        return new static(
+            $data['localField'],
+            $data['foreignSchema'],
+            $data['foreignTable'],
+            $data['foreignField'],
+        );
+    }
+}

--- a/src/Controller/ShopwareDatabaseController.php
+++ b/src/Controller/ShopwareDatabaseController.php
@@ -12,6 +12,8 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 /**
  * Provide integration for `swdb.dev` Shopware version comparison.
@@ -19,40 +21,73 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
 class ShopwareDatabaseController extends AbstractController
 {
+    private const CACHE_KEY_AVAILABLE_VERSIONS = 'frosh-tools-database-diff-available-versions';
+    private const CACHE_KEY_DIFF               = 'frosh-tools-database-diff';
+    private const CACHE_TTL_SECONDS            = 3600;
+
     public function __construct(
         #[Autowire(param: 'kernel.shopware_version')]
         private readonly string $shopwareVersion,
         private readonly DatabaseDiffService $databaseDiffService,
         private readonly DatabaseIntrospectionService $databaseIntrospectionService,
+        private readonly CacheInterface $cacheObject,
     ) {
     }
 
     #[Route(path: '/shopware-database-diff/available-versions', name: 'api.frosh.tools.shopware-database-diff.version', methods: ['GET'])]
-    public function fetchAvailableVersions(): JsonResponse
+    public function fetchAvailableVersions(Request $request): JsonResponse
     {
-        return new JsonResponse($this->databaseDiffService->getAvailableVersions());
+        if ($request->query->getBoolean('forceRefresh')) {
+            $this->cacheObject->deleteItem(self::CACHE_KEY_AVAILABLE_VERSIONS);
+        }
+
+        $availableVersions = $this->cacheObject->get(self::CACHE_KEY_AVAILABLE_VERSIONS, function (ItemInterface $cacheItem): array {
+            $cacheItem->expiresAfter(self::CACHE_TTL_SECONDS);
+
+            return $this->databaseDiffService->getAvailableVersions();
+        });
+
+        return new JsonResponse($availableVersions);
     }
 
     #[Route(path: '/shopware-database-diff/{version}', name: 'api.frosh.tools.shopware-database-diff.show', methods: ['GET'])]
     public function showDatabaseDiff(Request $request, string $version): JsonResponse
     {
-        if ($request->query->getBoolean('introspection')) {
-            $schemaA = $this->databaseIntrospectionService->getDatabaseSchema();
+        if ($introspection = $request->query->getBoolean('introspection')) {
+            $shopwareVersion = null;
         } else {
             $shopwareVersion = $this->getShopwareVersion();
 
             if (Kernel::SHOPWARE_FALLBACK_VERSION === $shopwareVersion) {
                 $shopwareVersion = \substr($shopwareVersion, 0,
-                    // Only use "6.6", and append ".0.0".
-                    \strpos($shopwareVersion, '.', 1 + \strpos($shopwareVersion, '.'))
-                ) . '.0.0';
+                        // Only use "6.6", and append ".0.0".
+                        \strpos($shopwareVersion, '.', 1 + \strpos($shopwareVersion, '.'))
+                    ) . '.0.0';
             }
-
-            $schemaA = $this->databaseDiffService->getDatabaseSchema($shopwareVersion);
         }
-        $schemaB = $this->databaseDiffService->getDatabaseSchema($version);
 
-        return new JsonResponse($this->databaseDiffService->createSchemaDiff($schemaA, $schemaB));
+        $version  = $this->databaseDiffService->parseVersionSlug($version);
+        $cacheKey = \sprintf('%s(%s:%s)%d', self::CACHE_KEY_DIFF,
+            $shopwareVersion ?? 'introspection', $version, (int)$introspection,
+        );
+
+
+        if ($request->query->getBoolean('forceRefresh')) {
+            $this->cacheObject->deleteItem($cacheKey);
+        }
+
+        $diff = $this->cacheObject->get($cacheKey, function (ItemInterface $cacheItem) use ($introspection, $shopwareVersion, $version) {
+            $cacheItem->expiresAfter(self::CACHE_TTL_SECONDS);
+
+            $schemaA = $shopwareVersion
+                ? $this->databaseDiffService->getDatabaseSchema($shopwareVersion)
+                : $this->databaseIntrospectionService->getDatabaseSchema();
+            $schemaB = $this->databaseDiffService->getDatabaseSchema($version);
+
+            return $this->databaseDiffService->createSchemaDiff($schemaA, $schemaB);
+        });
+
+        return new JsonResponse($diff);
     }
 
     private function getShopwareVersion(): string

--- a/src/Controller/ShopwareDatabaseController.php
+++ b/src/Controller/ShopwareDatabaseController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Controller;
+
+use Frosh\Tools\Components\DatabaseDiff\DatabaseDiffService;
+use Frosh\Tools\Components\DatabaseDiff\DatabaseIntrospectionService;
+use Shopware\Core\Kernel;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Provide integration for `swdb.dev` Shopware version comparison.
+ */
+#[Route(path: '/api/_action/frosh-tools', defaults: ['_routeScope' => ['api'], '_acl' => ['frosh_tools:read']])]
+class ShopwareDatabaseController extends AbstractController
+{
+    public function __construct(
+        #[Autowire(param: 'kernel.shopware_version')]
+        private readonly string $shopwareVersion,
+        private readonly DatabaseDiffService $databaseDiffService,
+        private readonly DatabaseIntrospectionService $databaseIntrospectionService,
+    ) {
+    }
+
+    #[Route(path: '/shopware-database-diff/available-versions', name: 'api.frosh.tools.shopware-database-diff.version', methods: ['GET'])]
+    public function fetchAvailableVersions(): JsonResponse
+    {
+        return new JsonResponse($this->databaseDiffService->getAvailableVersions());
+    }
+
+    #[Route(path: '/shopware-database-diff/{version}', name: 'api.frosh.tools.shopware-database-diff.show', methods: ['GET'])]
+    public function showDatabaseDiff(Request $request, string $version): JsonResponse
+    {
+        if ($request->query->getBoolean('introspection')) {
+            $schemaA = $this->databaseIntrospectionService->getDatabaseSchema();
+        } else {
+            $shopwareVersion = $this->getShopwareVersion();
+
+            if (Kernel::SHOPWARE_FALLBACK_VERSION === $shopwareVersion) {
+                $shopwareVersion = \substr($shopwareVersion, 0,
+                    // Only use "6.6", and append ".0.0".
+                    \strpos($shopwareVersion, '.', 1 + \strpos($shopwareVersion, '.'))
+                ) . '.0.0';
+            }
+
+            $schemaA = $this->databaseDiffService->getDatabaseSchema($shopwareVersion);
+        }
+        $schemaB = $this->databaseDiffService->getDatabaseSchema($version);
+
+        return new JsonResponse($this->databaseDiffService->createSchemaDiff($schemaA, $schemaB));
+    }
+
+    private function getShopwareVersion(): string
+    {
+        $shopwareVersion = \str_replace('.9999999.9999999-dev', '.9999999-dev', $this->shopwareVersion);
+
+        if (Kernel::SHOPWARE_FALLBACK_VERSION === $shopwareVersion) {
+            return $shopwareVersion;
+        }
+
+        return $this->shopwareVersion;
+    }
+}

--- a/src/Controller/ShopwareDatabaseController.php
+++ b/src/Controller/ShopwareDatabaseController.php
@@ -86,7 +86,7 @@ class ShopwareDatabaseController extends AbstractController
         $diff = $this->cacheObject->get($cacheKey, function (ItemInterface $cacheItem) use ($introspection, $shopwareVersion, $version) {
             $cacheItem->expiresAfter(self::CACHE_TTL_SECONDS);
 
-            $schemaA = $shopwareVersion
+            $schemaA = !$introspection
                 ? $this->databaseDiffService->getDatabaseSchema($shopwareVersion)
                 : $this->databaseIntrospectionService->getDatabaseSchema();
             $schemaB = $this->databaseDiffService->getDatabaseSchema($version);

--- a/src/Controller/ShopwareDatabaseController.php
+++ b/src/Controller/ShopwareDatabaseController.php
@@ -37,7 +37,11 @@ class ShopwareDatabaseController extends AbstractController
     #[Route(path: '/shopware-database-diff/available-versions', name: 'api.frosh.tools.shopware-database-diff.version', methods: ['GET'])]
     public function fetchAvailableVersions(Request $request): JsonResponse
     {
-        if ($request->query->getBoolean('forceRefresh')) {
+        if ($this->shopwareVersion === Kernel::SHOPWARE_FALLBACK_VERSION) {
+            return new JsonResponse(['error' => 'Git version is not supported']);
+        }
+
+        if ($request->query->getBoolean('refresh')) {
             $this->cacheObject->deleteItem(self::CACHE_KEY_AVAILABLE_VERSIONS);
         }
 
@@ -53,12 +57,16 @@ class ShopwareDatabaseController extends AbstractController
     #[Route(path: '/shopware-database-diff/{version}', name: 'api.frosh.tools.shopware-database-diff.show', methods: ['GET'])]
     public function showDatabaseDiff(Request $request, string $version): JsonResponse
     {
+        if ($this->shopwareVersion === Kernel::SHOPWARE_FALLBACK_VERSION) {
+            return new JsonResponse(['error' => 'Git version is not supported']);
+        }
+
         if ($introspection = $request->query->getBoolean('introspection')) {
             $shopwareVersion = null;
         } else {
-            $shopwareVersion = $this->getShopwareVersion();
+            $shopwareVersion = $this->shopwareVersion;
 
-            if (Kernel::SHOPWARE_FALLBACK_VERSION === $shopwareVersion) {
+            if (Kernel::SHOPWARE_FALLBACK_VERSION === \str_replace('.9999999.9999999-dev', '.9999999-dev', $shopwareVersion)) {
                 $shopwareVersion = \substr($shopwareVersion, 0,
                         // Only use "6.6", and append ".0.0".
                         \strpos($shopwareVersion, '.', 1 + \strpos($shopwareVersion, '.'))
@@ -71,8 +79,7 @@ class ShopwareDatabaseController extends AbstractController
             $shopwareVersion ?? 'introspection', $version, (int)$introspection,
         );
 
-
-        if ($request->query->getBoolean('forceRefresh')) {
+        if ($request->query->getBoolean('refresh')) {
             $this->cacheObject->deleteItem($cacheKey);
         }
 
@@ -88,16 +95,5 @@ class ShopwareDatabaseController extends AbstractController
         });
 
         return new JsonResponse($diff);
-    }
-
-    private function getShopwareVersion(): string
-    {
-        $shopwareVersion = \str_replace('.9999999.9999999-dev', '.9999999-dev', $this->shopwareVersion);
-
-        if (Kernel::SHOPWARE_FALLBACK_VERSION === $shopwareVersion) {
-            return $shopwareVersion;
-        }
-
-        return $this->shopwareVersion;
     }
 }

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -352,6 +352,17 @@ class FroshTools extends ApiService {
             });
     }
 
+    getDatabaseVersions() {
+        const apiRoute = `${this.getApiBasePath()}/shopware-database-diff/available-versions`;
+        return this.httpClient
+            .get(apiRoute, {
+                headers: this.getBasicHeaders(),
+            })
+            .then((response) => {
+                return ApiService.handleResponse(response);
+            });
+    }
+
     getDatabaseDiff(version, introspection = false) {
         const apiRoute = `${this.getApiBasePath()}/shopware-database-diff/${version}`;
         return this.httpClient

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -352,11 +352,12 @@ class FroshTools extends ApiService {
             });
     }
 
-    getDatabaseVersions() {
+    getDatabaseVersions(forceRefresh = false) {
         const apiRoute = `${this.getApiBasePath()}/shopware-database-diff/available-versions`;
         return this.httpClient
             .get(apiRoute, {
                 headers: this.getBasicHeaders(),
+                params: forceRefresh ? { forceRefresh: 1 } : {},
             })
             .then((response) => {
                 return ApiService.handleResponse(response);

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -357,19 +357,22 @@ class FroshTools extends ApiService {
         return this.httpClient
             .get(apiRoute, {
                 headers: this.getBasicHeaders(),
-                params: forceRefresh ? { forceRefresh: 1 } : {},
+                params: forceRefresh ? { refresh: 1 } : {},
             })
             .then((response) => {
                 return ApiService.handleResponse(response);
             });
     }
 
-    getDatabaseDiff(version, introspection = false) {
+    getDatabaseDiff(version, introspection = false, forceRefresh = false) {
         const apiRoute = `${this.getApiBasePath()}/shopware-database-diff/${version}`;
         return this.httpClient
             .get(apiRoute, {
                 headers: this.getBasicHeaders(),
-                params: introspection ? { introspection: 1 } : {},
+                params: {
+                    introspection: Number(introspection),
+                    refresh: Number(forceRefresh),
+                },
             })
             .then((response) => {
                 return ApiService.handleResponse(response);

--- a/src/Resources/app/administration/src/api/frosh-tools.js
+++ b/src/Resources/app/administration/src/api/frosh-tools.js
@@ -352,6 +352,18 @@ class FroshTools extends ApiService {
             });
     }
 
+    getDatabaseDiff(version, introspection = false) {
+        const apiRoute = `${this.getApiBasePath()}/shopware-database-diff/${version}`;
+        return this.httpClient
+            .get(apiRoute, {
+                headers: this.getBasicHeaders(),
+                params: introspection ? { introspection: 1 } : {},
+            })
+            .then((response) => {
+                return ApiService.handleResponse(response);
+            });
+    }
+
     getFastlyStatus() {
         const apiRoute = `${this.getApiBasePath()}/fastly/status`;
         return this.httpClient

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/index.js
@@ -85,7 +85,7 @@ Component.register('frosh-tools-tab-database-diff', {
 
             try {
                 if (forceRefresh || !this.version.available.length) {
-                    await this.loadVersions();
+                    await this.loadVersions(forceRefresh);
                 }
 
                 const version = this.version.target?.version;
@@ -93,7 +93,7 @@ Component.register('frosh-tools-tab-database-diff', {
                     throw new Error('No target version selected');
                 }
 
-                this.diff = await this.froshToolsService.getDatabaseDiff(version, this.introspection);
+                this.diff = await this.froshToolsService.getDatabaseDiff(version, this.introspection, forceRefresh);
 
                 this.version.selected = this.version.target;
             } catch (error) {
@@ -102,20 +102,20 @@ Component.register('frosh-tools-tab-database-diff', {
 
                 this.createNotificationError({ message: this.loadError });
 
-                //throw error;
+                throw error;
             } finally {
                 this.isLoading = false;
             }
         },
 
-        async loadVersions() {
-            this.version.available = Object.values(await this.froshToolsService.getDatabaseVersions());
+        async loadVersions(forceRefresh = false) {
+            this.version.available = Object.values(await this.froshToolsService.getDatabaseVersions(forceRefresh));
 
             if (this.version.target) {
                 return;
             }
 
-            this.version.target    = this.version.available[this.version.available.length - 1] ?? null;
+            this.version.target = this.version.available[this.version.available.length - 1] ?? null;
         },
 
         async onVersionChanged(slug) {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/index.js
@@ -1,0 +1,135 @@
+import template from './template.html.twig';
+import './style.scss';
+
+const { Component, Mixin } = Shopware;
+
+Component.register('frosh-tools-tab-database-diff', {
+    template,
+    inject: {
+        froshToolsService: { from: 'froshToolsService' },
+        froshToolsSearch: { default: null },
+    },
+    mixins: [
+        Mixin.getByName('notification'),
+        Mixin.getByName('frosh-sortable-table'),
+    ],
+
+    data() {
+        return {
+            diff: null,
+            isLoading: true,
+            loadError: null,
+            version: {
+                // current latest: 2026-08-21
+                selected: null,
+                target: '6.7.12.2',
+                // TODO: Populate
+                current: null,
+            },
+            introspection: false,
+        };
+    },
+
+    created() {
+        this.createdComponent();
+    },
+
+    computed: {
+        searchTerm() {
+            return this.froshToolsSearch?.searchTerm ?? '';
+        },
+
+        visibleTables() {
+            return this.filterRows(this.diff, this.searchTerm, [
+                'table', 'name',
+                'valueA', 'valueB',
+            ]);
+        },
+
+        summary() {
+            let summary = {};
+            for (const item of this.diff) {
+                const severity = this.severityForLabel(item.label);
+
+                if (!summary.hasOwnProperty(severity)) {
+                    summary[severity] = 0;
+                }
+
+                ++summary[severity];
+            }
+            return summary;
+        },
+    },
+
+    methods: {
+        async refresh() {
+            await this.load();
+        },
+
+        async createdComponent() {
+            await this.load();
+        },
+
+        async load() {
+            this.isLoading = true;
+            this.loadError = null;
+
+            // TODO: Only refresh if matching version number pattern "6|5.X.Y.Z".
+
+            try {
+                const version = this.version.target;
+                // TODO: Add support for "introspection" query parameter and current database inspection.
+                this.diff =
+                    await this.froshToolsService.getDatabaseDiff(version, this.introspection);
+
+                this.version.selected = version;
+            } catch (error) {
+                this.diff = null;
+                this.loadError = error?.response?.data?.error ?? error.message;
+
+                this.createNotificationError({ message: this.loadError });
+
+                throw error;
+            } finally {
+                this.isLoading = false;
+            }
+        },
+
+        onVersionChange(version) {
+            // TODO: Validate pattern?
+            // TODO: Or switch to sw-select component (with available-versions endpoint).
+        },
+
+        onChangeIntrospection(introspection) {
+            this.introspection = introspection;
+
+            this.refresh();
+        },
+
+        variantForLabel(label) {
+            switch (label) {
+                case 'added':
+                    return 'success';
+                case 'removed':
+                    return 'danger';
+                case 'modified':
+                    return 'warning';
+                default:
+                    throw new Error(`Unknown label type ${label}`);
+            }
+        },
+
+        severityForLabel(label) {
+            switch (label) {
+                case 'added':
+                    return 'low';
+                case 'removed':
+                    return 'high';
+                case 'modified':
+                    return 'medium';
+                default:
+                    throw new Error(`Unknown label type ${label}`);
+            }
+        },
+    },
+});

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/index.js
@@ -22,9 +22,8 @@ Component.register('frosh-tools-tab-database-diff', {
             version: {
                 // current latest: 2026-08-21
                 selected: null,
-                target: '6.7.12.2',
-                // TODO: Populate
-                current: null,
+                target: null,
+                available: [],
             },
             introspection: false,
         };
@@ -59,30 +58,38 @@ Component.register('frosh-tools-tab-database-diff', {
             }
             return summary;
         },
+
+        availableVersions() {
+            return this.version.available.map((item) => ({
+                id:   item.version,
+                name: item.version,
+            }));
+        },
     },
 
     methods: {
         async refresh() {
-            await this.load();
+            await this.load(true);
         },
 
         async createdComponent() {
-            await this.load();
+            await this.load(true);
         },
 
-        async load() {
+        async load(forceRefresh = false) {
             this.isLoading = true;
             this.loadError = null;
 
-            // TODO: Only refresh if matching version number pattern "6|5.X.Y.Z".
-
             try {
-                const version = this.version.target;
-                // TODO: Add support for "introspection" query parameter and current database inspection.
-                this.diff =
-                    await this.froshToolsService.getDatabaseDiff(version, this.introspection);
+                if (forceRefresh || !this.version.available.length) {
+                    this.version.available = Object.values(await this.froshToolsService.getDatabaseVersions());
+                    this.version.target  ??= (this.version.available[this.version.available.length - 1] ?? null)?.version;
+                }
 
-                this.version.selected = version;
+                const version = this.version.target;
+                this.diff     = await this.froshToolsService.getDatabaseDiff(version, this.introspection);
+
+                this.version.selected  = version;
             } catch (error) {
                 this.diff = null;
                 this.loadError = error?.response?.data?.error ?? error.message;
@@ -95,15 +102,14 @@ Component.register('frosh-tools-tab-database-diff', {
             }
         },
 
-        onVersionChange(version) {
-            // TODO: Validate pattern?
-            // TODO: Or switch to sw-select component (with available-versions endpoint).
+        async onVersionChanged() {
+            await this.load();
         },
 
-        onChangeIntrospection(introspection) {
+        async onChangeIntrospection(introspection) {
             this.introspection = introspection;
 
-            this.refresh();
+            await this.load();
         },
 
         variantForLabel(label) {

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/index.js
@@ -20,7 +20,6 @@ Component.register('frosh-tools-tab-database-diff', {
             isLoading: true,
             loadError: null,
             version: {
-                // current latest: 2026-08-21
                 selected: null,
                 target: null,
                 available: [],
@@ -61,9 +60,13 @@ Component.register('frosh-tools-tab-database-diff', {
 
         availableVersions() {
             return this.version.available.map((item) => ({
-                id:   item.version,
+                id:   item.slug,
                 name: item.version,
             }));
+        },
+
+        selectedVersion() {
+            return this.version.target?.slug;
         },
     },
 
@@ -82,27 +85,42 @@ Component.register('frosh-tools-tab-database-diff', {
 
             try {
                 if (forceRefresh || !this.version.available.length) {
-                    this.version.available = Object.values(await this.froshToolsService.getDatabaseVersions());
-                    this.version.target  ??= (this.version.available[this.version.available.length - 1] ?? null)?.version;
+                    await this.loadVersions();
                 }
 
-                const version = this.version.target;
-                this.diff     = await this.froshToolsService.getDatabaseDiff(version, this.introspection);
+                const version = this.version.target?.version;
+                if (!version) {
+                    throw new Error('No target version selected');
+                }
 
-                this.version.selected  = version;
+                this.diff = await this.froshToolsService.getDatabaseDiff(version, this.introspection);
+
+                this.version.selected = this.version.target;
             } catch (error) {
                 this.diff = null;
                 this.loadError = error?.response?.data?.error ?? error.message;
 
                 this.createNotificationError({ message: this.loadError });
 
-                throw error;
+                //throw error;
             } finally {
                 this.isLoading = false;
             }
         },
 
-        async onVersionChanged() {
+        async loadVersions() {
+            this.version.available = Object.values(await this.froshToolsService.getDatabaseVersions());
+
+            if (this.version.target) {
+                return;
+            }
+
+            this.version.target    = this.version.available[this.version.available.length - 1] ?? null;
+        },
+
+        async onVersionChanged(slug) {
+            this.version.target = this.version.available.find(item => item.slug === slug) ?? null;
+
             await this.load();
         },
 
@@ -136,6 +154,14 @@ Component.register('frosh-tools-tab-database-diff', {
                 default:
                     throw new Error(`Unknown label type ${label}`);
             }
+        },
+
+        openLinkForVersion(version) {
+            if (!version.slug) return;
+
+            const url = `https://swdb.dev/version/${version.slug}/`;
+
+            window.open(url, '_blank');
         },
     },
 });

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/style.scss
@@ -1,0 +1,11 @@
+.frosh-tab-swdb {
+    display: block;
+}
+
+.frosh-tab-swdb .ft-page-head__actions {
+    flex-wrap: nowrap;
+}
+
+.frosh-tab-swdb .ft-page-head__actions .sw-field--checkbox {
+    margin: 6px;
+}

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/style.scss
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/style.scss
@@ -9,3 +9,7 @@
 .frosh-tab-swdb .ft-page-head__actions .sw-field--checkbox {
     margin: 6px;
 }
+
+.frosh-tab-swdb .frosh-tab-swdb__external-link {
+    padding: 17px;
+}

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/template.html.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/template.html.twig
@@ -5,7 +5,7 @@
     >
         <template #actions>
             <sw-select-field
-                v-model:value="version.target"
+                v-model="selectedVersion"
                 name="sw-field--selectedVersion"
                 size="small"
                 @update:value="onVersionChanged"
@@ -93,7 +93,7 @@
                         >{{ $t('frosh-tools.tabs.database-diff.name') }}</ft-th-sort>
                         <th>{{ $t('frosh-tools.tabs.database-diff.valueA') }}</th>
                         <th>{{ $t('frosh-tools.tabs.database-diff.valueB', {
-                                'version': version.selected,
+                                version: version.selected?.version,
                             }) }}</th>
                     </tr>
                 </thead>
@@ -121,4 +121,16 @@
             </table>
         </div>
     </ft-panel>
+    <p class="swdb-external-link">
+        <a v-if="version.selected"
+           class="ft-link"
+           @click="openLinkForVersion(version.selected)"
+        >
+            {{ $t('frosh-tools.tabs.database-diff.externalLink', {
+                version: version.selected?.version,
+            }) }}
+
+            <ft-icon name="external-link"/>
+        </a>
+    </p>
 </div>

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/template.html.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/template.html.twig
@@ -1,0 +1,125 @@
+<div class="ft frosh-tab-swdb">
+    <ft-page-head
+        :title="$tc('frosh-tools.tabs.database-diff.title')"
+        :subtitle="$t('frosh-tools.tabs.database-diff.subtitle')"
+    >
+        <template #actions>
+            <!-- TODO: Use combined textbox + button component. -->
+            <sw-text-field
+                v-model:value="version.target"
+                :placeholder="$t('frosh-tools.tabs.database-diff.selectedVersion')"
+                :label="$t('frosh-tools.tabs.database-diff.selectedVersionLabel')"
+                key="string"
+                name="sw-field--selectedVersion"
+                size="small"
+                @update:value="onVersionChange"
+                class="sw-text-field__swdb-version"
+            />
+            <sw-checkbox-field
+                :value="introspection"
+                @update:value="onChangeIntrospection"
+            >
+                <template #label>
+                    {{ $tc('frosh-tools.tabs.database-diff.introspection') }}
+                </template>
+            </sw-checkbox-field>
+            <ft-refresh-button
+                :loading="isLoading"
+                @click="createdComponent"
+            />
+        </template>
+    </ft-page-head>
+    <ft-panel v-if="diff || loadError"
+              class="frosh-tab-swdb__hero">
+        <ft-severity-bar
+            v-if="diff"
+            :summary="summary"
+            :loading="isLoading"
+        />
+        <ft-hero-state
+            v-if="loadError"
+            variant="danger"
+            icon="alert"
+            :title="$t('frosh-tools.loadError.title')"
+            :body="loadError"
+        >
+            <template #actions>
+                <ft-button
+                    icon="refresh"
+                    @click="refresh"
+                >
+                    {{ $t('frosh-tools.loadError.retry') }}
+                </ft-button>
+            </template>
+        </ft-hero-state>
+    </ft-panel>
+    <ft-panel
+        v-if="diff"
+        :title="$t('frosh-tools.tabs.database-diff.diff')"
+        :count="visibleTables ? visibleTables.length : 0"
+        flush
+    >
+        <ft-empty
+            v-if="isLoading && !diff"
+            loading
+        />
+        <ft-empty
+            v-else-if="!diff || !diff.length"
+            :title="$t('frosh-tools.tabs.database-diff.noInfo')"
+        />
+        <ft-empty
+            v-else-if="!visibleTables.length"
+            icon="search"
+            :title="$t('frosh-tools.search.noResults', { term: searchTerm })"
+        />
+        <div
+            v-else
+            class="ft-table-wrap"
+        >
+            <table class="ft-table">
+                <thead>
+                    <tr>
+                        <ft-th-sort
+                            sort-key="table"
+                            style="width: 110px;"
+                        >{{ $t('frosh-tools.tabs.database-diff.table') }}</ft-th-sort>
+                        <ft-th-sort
+                            sort-key="label"
+                        >{{ $t('frosh-tools.tabs.database-diff.label') }}</ft-th-sort>
+                        <ft-th-sort
+                            sort-key="type"
+                        >{{ $t('frosh-tools.tabs.database-diff.type') }}</ft-th-sort>
+                        <ft-th-sort
+                            sort-key="name"
+                        >{{ $t('frosh-tools.tabs.database-diff.name') }}</ft-th-sort>
+                        <th>{{ $t('frosh-tools.tabs.database-diff.valueA') }}</th>
+                        <th>{{ $t('frosh-tools.tabs.database-diff.valueB', {
+                                'version': version.selected,
+                            }) }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr
+                        v-for="item in sortRows(visibleTables)"
+                        :key="`${item.table}.${item.type}.${item.name}:${item.label}`"
+                    >
+                        <td class="ft-table__table">
+                            <code class="ft-mono">{{ item.table }}</code>
+                        </td>
+                        <td class="ft-table__label">
+                            <sw-label
+                                size="medium"
+                                appearance="pill"
+                                :variant="variantForLabel(item.label)"
+                            >{{ item.label }}</sw-label>
+                        </td>
+                        <td class="ft-table__type ft-mono">{{ item.type }}</td>
+                        <td class="ft-table__name ft-mono">{{ item.name }}</td>
+                        <td class="ft-table__value-A ft-mono">{{ item.valueA }}</td>
+                        <td class="ft-table__value-B ft-mono">{{ item.valueB }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </ft-panel>
+</div>

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/template.html.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/template.html.twig
@@ -4,16 +4,16 @@
         :subtitle="$t('frosh-tools.tabs.database-diff.subtitle')"
     >
         <template #actions>
-            <!-- TODO: Use combined textbox + button component. -->
-            <sw-text-field
+            <sw-select-field
                 v-model:value="version.target"
-                :placeholder="$t('frosh-tools.tabs.database-diff.selectedVersion')"
-                :label="$t('frosh-tools.tabs.database-diff.selectedVersionLabel')"
-                key="string"
                 name="sw-field--selectedVersion"
                 size="small"
-                @update:value="onVersionChange"
+                @update:value="onVersionChanged"
                 class="sw-text-field__swdb-version"
+                :placeholder="$t('frosh-tools.tabs.database-diff.selectedVersion')"
+                :label="$t('frosh-tools.tabs.database-diff.selectedVersionLabel')"
+                :is-loading="isLoading"
+                :options="availableVersions"
             />
             <sw-checkbox-field
                 :value="introspection"
@@ -54,7 +54,6 @@
         </ft-hero-state>
     </ft-panel>
     <ft-panel
-        v-if="diff"
         :title="$t('frosh-tools.tabs.database-diff.diff')"
         :count="visibleTables ? visibleTables.length : 0"
         flush

--- a/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/template.html.twig
+++ b/src/Resources/app/administration/src/module/frosh-tools/component/frosh-tools-tab-database-diff/template.html.twig
@@ -121,7 +121,7 @@
             </table>
         </div>
     </ft-panel>
-    <p class="swdb-external-link">
+    <p class="frosh-tab-swdb__external-link">
         <a v-if="version.selected"
            class="ft-link"
            @click="openLinkForVersion(version.selected)"

--- a/src/Resources/app/administration/src/module/frosh-tools/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/index.js
@@ -14,6 +14,7 @@ import './component/frosh-tools-tab-queue';
 import './component/frosh-tools-tab-scheduled';
 import './component/frosh-tools-tab-elasticsearch';
 import './component/frosh-tools-tab-feature-flags';
+import './component/frosh-tools-tab-database-diff';
 import './component/frosh-tools-tab-logs';
 import './component/frosh-tools-tab-state-machines';
 import './component/ft-severity-bar';
@@ -84,6 +85,14 @@ Shopware.Module.register('frosh-tools', {
                 featureflags: {
                     component: 'frosh-tools-tab-feature-flags',
                     path: 'feature-flags',
+                    meta: {
+                        privilege: 'frosh_tools:read',
+                        parentPath: 'frosh.tools.index.index',
+                    },
+                },
+                databasediff: {
+                    component: 'frosh-tools-tab-database-diff',
+                    path: 'database-diff',
                     meta: {
                         privilege: 'frosh_tools:read',
                         parentPath: 'frosh.tools.index.index',

--- a/src/Resources/app/administration/src/module/frosh-tools/page/index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-tools/page/index/index.js
@@ -43,6 +43,10 @@ const SEARCHABLE_TABS = {
         type: 'frosh_tools_feature_flags',
         placeholderKey: 'frosh-tools.search.placeholder.featureFlags',
     },
+    'frosh.tools.index.databasediff': {
+        type: 'frosh_tools_database_diff',
+        placeholderKey: 'frosh-tools.search.placeholder.databaseDiff',
+    },
 };
 
 Component.register('frosh-tools-index', {
@@ -158,6 +162,10 @@ Component.register('frosh-tools-index', {
             diagnostics.push({
                 route: 'frosh.tools.index.featureflags',
                 labelKey: 'frosh-tools.tabs.feature-flags.title',
+            });
+            diagnostics.push({
+                route: 'frosh.tools.index.databasediff',
+                labelKey: 'frosh-tools.tabs.database-diff.title',
             });
 
             const cdn = [];

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -164,6 +164,21 @@
                 "deactivate": "Deaktivieren",
                 "activate": "Aktivieren"
             },
+            "database-diff": {
+                "title": "Datenbank Vergleich",
+                "subtitle": "Ein Vergleich der aktuellen und einer beliebigen Datenbank Schema Version von Shopware.",
+                "diff": "Unterscheide",
+                "noInfo": "Keine Information verfügbar",
+                "selectedVersion":  "v6.X.Y.Z",
+                "selectedVersionLabel": "Ausgewählt Shopware Version",
+                "table": "Tabelle",
+                "label": "Art",
+                "type": "Kategorie",
+                "name": "Name",
+                "valueA": "Aktuelle Version",
+                "valueB": "Version {version}",
+                "introspection": "Live Analyse"
+            },
             "files": {
                 "title": "Shopware Dateien Checker",
                 "allFilesOk": "Alle Dateien entsprechen den Originalen, es wurden keine Manipulationen erkannt",
@@ -499,7 +514,8 @@
                 "queue": "Transporte durchsuchen\u2026",
                 "scheduled": "Geplante Aufgaben durchsuchen\u2026",
                 "elasticsearch": "Indizes durchsuchen\u2026",
-                "featureFlags": "Feature-Flags durchsuchen\u2026"
+                "featureFlags": "Feature-Flags durchsuchen\u2026",
+                "databaseDiff": "Datenbank-Schema Unterschiede durchsuchen\u2026"
             },
             "noResults": "Keine Ergebnisse für \"{term}\""
         },
@@ -523,7 +539,8 @@
             "frosh_tools_queue": "Warteschlange",
             "frosh_tools_scheduled_task": "Geplante Aufgaben",
             "frosh_tools_elasticsearch": "Indizes",
-            "frosh_tools_feature_flags": "Feature Flags"
+            "frosh_tools_feature_flags": "Feature Flags",
+            "frosh_tools_database_diff": "Datenbank Unterschiede"
         }
     }
 }

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/de-DE.json
@@ -177,7 +177,8 @@
                 "name": "Name",
                 "valueA": "Aktuelle Version",
                 "valueB": "Version {version}",
-                "introspection": "Live Analyse"
+                "introspection": "Live Analyse",
+                "externalLink": "Die Dokumentation aller Tabellen der Version {version} gibt es auf swdb.dev"
             },
             "files": {
                 "title": "Shopware Dateien Checker",

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -164,6 +164,21 @@
                 "deactivate": "Deactivate",
                 "activate": "Activate"
             },
+            "database-diff": {
+                "title": "Database Diff",
+                "subtitle": "A comparison of the current and a target database schema version of Shopware.",
+                "diff": "Diff",
+                "noInfo": "No information available",
+                "selectedVersion":  "v6.X.Y.Z",
+                "selectedVersionLabel": "Selected Shopware version",
+                "table": "Table name",
+                "label": "Type",
+                "type": "Category",
+                "name": "Name",
+                "valueA": "Current version",
+                "valueB": "Version {version}",
+                "introspection": "Live introspection"
+            },
             "files": {
                 "title": "Shopware File Checker",
                 "allFilesOk": "No files modified",
@@ -499,7 +514,8 @@
                 "queue": "Search transports\u2026",
                 "scheduled": "Search scheduled tasks\u2026",
                 "elasticsearch": "Search indices\u2026",
-                "featureFlags": "Search feature flags\u2026"
+                "featureFlags": "Search feature flags\u2026",
+                "databaseDiff": "Search database differences\u2026"
             },
             "noResults": "No results for \"{term}\""
         },
@@ -523,7 +539,8 @@
             "frosh_tools_queue": "Queue",
             "frosh_tools_scheduled_task": "Scheduled Tasks",
             "frosh_tools_elasticsearch": "Search indices",
-            "frosh_tools_feature_flags": "Feature Flags"
+            "frosh_tools_feature_flags": "Feature Flags",
+            "frosh_tools_database_diff": "Database Diff"
         }
     }
 }

--- a/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-tools/snippet/en-GB.json
@@ -177,7 +177,8 @@
                 "name": "Name",
                 "valueA": "Current version",
                 "valueB": "Version {version}",
-                "introspection": "Live introspection"
+                "introspection": "Live introspection",
+                "externalLink": "View the full table documentation of version {version} at swdb.dev"
             },
             "files": {
                 "title": "Shopware File Checker",

--- a/tests/Components/DatabaseDiff/DatabaseDiffServiceTest.php
+++ b/tests/Components/DatabaseDiff/DatabaseDiffServiceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\DatabaseDiff;
+
+use Frosh\Tools\Components\DatabaseDiff\DatabaseDiffService;
+use Frosh\Tools\Components\DatabaseDiff\Swdb;
+use Frosh\Tools\Tests\Components\DatabaseDiff\Swdb\ModelTest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Validation\DataValidator;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+#[CoversClass(DatabaseDiffService::class)]
+class DatabaseDiffServiceTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    protected const EXAMPLE_VERSION = ModelTest::VERSION_A;
+
+    protected const JSON__SCHEMA_A  = ModelTest::JSON__SCHEMA_A;
+    protected const JSON__SCHEMA_B  = ModelTest::JSON__SCHEMA_B;
+
+    protected const JSON__AVAILABLE_VERSIONS = <<<'JSON'
+[{
+  "version": "6.6.10.0",
+  "slug": "6_6_10_0",
+  "major": 6,
+  "minor": 6,
+  "majorMinor": "6.6",
+  "status": "available",
+  "tableCount": 229,
+  "url": "https://swdb.dev/version/6_6_10_0/",
+  "schemaUrl": "https://swdb.dev/api/schemas/6_6_10_0.schema.json"
+}, {
+  "version": "6.7.13.0",
+  "slug": "6_7_13_0",
+  "major": 6,
+  "minor": 7,
+  "majorMinor": "6.7",
+  "status": "available",
+  "tableCount": 252,
+  "url": "https://swdb.dev/version/6_7_13_0/",
+  "schemaUrl": "https://swdb.dev/api/schemas/6_7_13_0.schema.json"
+}]
+JSON;
+
+    public function testLoadAvailableVersions(): void
+    {
+        $versions = static::JSON__AVAILABLE_VERSIONS;
+
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse($versions),
+        ]);
+        $dataValidator  = $this->getContainer()
+            ->get(DataValidator::class);
+
+        $service = new DatabaseDiffService(
+            $mockHttpClient,
+            $dataValidator,
+        );
+
+        self::assertSame(Json::decodeToList($versions),
+            \array_values($service->getAvailableVersions())
+        );
+    }
+
+    public function testLoadDatabaseSchema(): void
+    {
+        $version = static::EXAMPLE_VERSION;
+
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse(static::JSON__SCHEMA_A),
+        ]);
+        $dataValidator  = $this->getContainer()
+            ->get(DataValidator::class);
+
+        $service = new DatabaseDiffService(
+            $mockHttpClient,
+            $dataValidator,
+        );
+
+        $schema = $service->getDatabaseSchema($version);
+
+        self::assertInstanceOf(Swdb\Schema::class, $schema);
+        self::assertCount(2, $schema->tables);
+        self::assertSame($service->parseVersionSlug($version), $schema->version);
+        self::assertSame(['cart', 'payment_token'], \array_keys($schema->tables));
+    }
+
+    #[DataProvider('provideVersions')]
+    public function testParseVersionSlug(string $version, string $expectedSlug): void
+    {
+        $slug = $this->getContainer()
+            ->get(DatabaseDiffService::class)
+            ->parseVersionSlug($version);
+
+        self::assertSame($expectedSlug, $slug);
+    }
+
+    public static function provideVersions(): iterable
+    {
+        yield 'normal version'            => ['6.6.10.0',  '6_6_10_0'];
+        yield 'release candidate version' => ['6.1.0.rc1', '6_1_0_rc1'];
+    }
+
+    public function testCreateSchemaDiff(): void
+    {
+        $versionA = static::EXAMPLE_VERSION;
+        $versionB = '6.6.10.0';
+
+        $mockHttpClient = new MockHttpClient([
+            new MockResponse(static::JSON__SCHEMA_A),
+            new MockResponse(static::JSON__SCHEMA_B),
+        ]);
+        $dataValidator  = $this->getContainer()
+            ->get(DataValidator::class);
+
+        $service = new DatabaseDiffService(
+            $mockHttpClient,
+            $dataValidator,
+        );
+
+        $schemaA = $service->getDatabaseSchema($versionA);
+        $schemaB = $service->getDatabaseSchema($versionB);
+
+        $diff = $this->getContainer()
+            ->get(DatabaseDiffService::class)
+            ->createSchemaDiff($schemaA, $schemaB);
+
+        self::assertNotEmpty($diff);
+        self::assertEquals([
+            'table'  => 'payment_token',
+            'type'   => 'fields',
+            'label'  => 'removed',
+            'name'   => 'payment_token.consumed',
+            'valueA' => 'tinyint(1) null default "0"',
+            'valueB' => null,
+        ], $diff[0]);
+    }
+}

--- a/tests/Components/DatabaseDiff/DatabaseIntrospectionServiceTest.php
+++ b/tests/Components/DatabaseDiff/DatabaseIntrospectionServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\DatabaseDiff;
+
+use Doctrine\DBAL\Connection;
+use Frosh\Tools\Components\DatabaseDiff\DatabaseIntrospectionService;
+use Frosh\Tools\Components\DatabaseDiff\Swdb;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+#[CoversClass(DatabaseIntrospectionService::class)]
+class DatabaseIntrospectionServiceTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testIntrospectDatabaseSchema(): void
+    {
+        $version = $this->getContainer()
+            ->getParameter('kernel.shopware_version');
+        $service = $this->getContainer()
+            ->get(DatabaseIntrospectionService::class);
+        $schema  = $service->getDatabaseSchema();
+
+        self::assertSame($version, $schema->version);
+        self::assertNotEmpty($schema->tables);
+    }
+
+    public function testIntrospectCustomTable(): void
+    {
+        $this->ensureCustomTableExists();
+
+        $version = $this->getContainer()
+            ->getParameter('kernel.shopware_version');
+        $service = $this->getContainer()
+            ->get(DatabaseIntrospectionService::class);
+        $schema  = $service->getDatabaseSchema();
+
+        self::assertSame($version, $schema->version);
+        self::assertNotEmpty($schema->tables);
+
+        self::assertArrayHasKey('frosh_db_diff_test', $schema->tables);
+        $table   = $schema->tables['frosh_db_diff_test'];
+
+        self::assertInstanceOf(Swdb\Table::class, $table);
+        self::assertSame('frosh_db_diff_test', $table->table);
+        self::assertCount(4, $table->fields);
+        self::assertEquals(['id', 'name', 'created_at', 'updated_at'], \array_keys($table->fields));
+        self::assertCount(1, $table->indexes);
+        self::assertEquals(['primary'], \array_keys($table->indexes));
+
+        self::assertArrayHasKey('id', $table->fields);
+        $field   = $table->fields['id'];
+
+        self::assertInstanceOf(Swdb\TableField::class, $field);
+        self::assertSame('frosh_db_diff_test', $field->table);
+        self::assertSame('fields', $field->type());
+        self::assertSame('frosh_db_diff_test.id', $field->key());
+        self::assertSame('binary(16) not null default null /* key=PRI */', $field->value());
+    }
+
+    private function ensureCustomTableExists(): void
+    {
+        $this->stopTransactionAfter();
+
+        $connection = $this->getContainer()
+            ->get(Connection::class);
+        $connection->executeStatement(<<<'SQL'
+CREATE TABLE IF NOT EXISTS `frosh_db_diff_test` (
+    `id`         binary(16)   NOT NULL,
+    `name`       varchar(255) NOT NULL,
+    `created_at` DATETIME(3)  NOT NULL,
+    `updated_at` DATETIME(3)      NULL,
+
+    PRIMARY KEY `id` (`id`)
+);
+SQL
+        );
+
+        $this->startTransactionBefore();
+    }
+}

--- a/tests/Components/DatabaseDiff/Swdb/ModelTest.php
+++ b/tests/Components/DatabaseDiff/Swdb/ModelTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Tools\Tests\Components\DatabaseDiff\Swdb;
+
+use Frosh\Tools\Components\DatabaseDiff\Swdb;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Util\Json;
+
+#[CoversClass(Swdb\Schema::class)]
+#[CoversClass(Swdb\Table::class)]
+#[CoversClass(Swdb\TableField::class)]
+#[CoversClass(Swdb\TableIndex::class)]
+#[CoversClass(Swdb\TableRelation::class)]
+#[CoversClass(Swdb\InverseTableRelation::class)]
+class ModelTest extends TestCase
+{
+    public const VERSION_A = '6.7.13.0';
+    public const VERSION_B = '6.6.10.0';
+
+    public const JSON__SCHEMA_A           = <<<'JSON'
+[{
+  "fields": [
+    {
+      "Field": "token",
+      "Type": "varchar(50)",
+      "Null": false,
+      "Key": "PRI",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "rule_ids",
+      "Type": "json",
+      "Null": false,
+      "Key": "",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "created_at",
+      "Type": "datetime(3)",
+      "Null": false,
+      "Key": "MUL",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "auto_increment",
+      "Type": "bigint",
+      "Null": false,
+      "Key": "UNI",
+      "Default": null,
+      "Extra": "auto_increment"
+    },
+    {
+      "Field": "compressed",
+      "Type": "tinyint(1)",
+      "Null": false,
+      "Key": "",
+      "Default": "0",
+      "Extra": ""
+    },
+    {
+      "Field": "payload",
+      "Type": "longblob",
+      "Null": true,
+      "Key": "",
+      "Default": null,
+      "Extra": ""
+    }
+  ],
+  "relationsFromTable": [],
+  "relationsToTable": [],
+  "indexes": [
+    {
+      "Index": "auto_increment",
+      "Columns": "auto_increment",
+      "Unique": 1
+    },
+    {
+      "Index": "idx.cart.created_at",
+      "Columns": "created_at",
+      "Unique": 0
+    },
+    {
+      "Index": "PRIMARY",
+      "Columns": "token",
+      "Unique": 1
+    }
+  ],
+  "table": "cart"
+},
+{
+  "fields": [
+    {
+      "Field": "token",
+      "Type": "char(32)",
+      "Null": false,
+      "Key": "PRI",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "expires",
+      "Type": "datetime(3)",
+      "Null": false,
+      "Key": "",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "consumed",
+      "Type": "tinyint(1)",
+      "Null": true,
+      "Key": "",
+      "Default": "0",
+      "Extra": ""
+    }
+  ],
+  "relationsFromTable": [],
+  "relationsToTable": [],
+  "indexes": [
+    {
+      "Index": "PRIMARY",
+      "Columns": "token",
+      "Unique": 1
+    }
+  ],
+  "table": "payment_token"
+}]
+JSON;
+    public const JSON__SCHEMA_B           = <<<'JSON'
+[{
+  "fields": [
+    {
+      "Field": "token",
+      "Type": "varchar(50)",
+      "Null": false,
+      "Key": "PRI",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "rule_ids",
+      "Type": "json",
+      "Null": false,
+      "Key": "",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "created_at",
+      "Type": "datetime(3)",
+      "Null": false,
+      "Key": "MUL",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "auto_increment",
+      "Type": "bigint",
+      "Null": false,
+      "Key": "UNI",
+      "Default": null,
+      "Extra": "auto_increment"
+    },
+    {
+      "Field": "compressed",
+      "Type": "tinyint(1)",
+      "Null": false,
+      "Key": "",
+      "Default": "0",
+      "Extra": ""
+    },
+    {
+      "Field": "payload",
+      "Type": "longblob",
+      "Null": true,
+      "Key": "",
+      "Default": null,
+      "Extra": ""
+    }
+  ],
+  "relationsFromTable": [],
+  "relationsToTable": [],
+  "indexes": [
+      {
+          "Index": "auto_increment",
+          "Columns": "auto_increment",
+          "Unique": 1
+      },
+      {
+          "Index": "idx.cart.created_at",
+          "Columns": "created_at",
+          "Unique": 0
+      },
+      {
+          "Index": "PRIMARY",
+          "Columns": "token",
+          "Unique": 1
+      }
+  ],
+  "table": "cart"
+}, {
+  "fields": [
+    {
+      "Field": "token",
+      "Type": "char(32)",
+      "Null": false,
+      "Key": "PRI",
+      "Default": null,
+      "Extra": ""
+    },
+    {
+      "Field": "expires",
+      "Type": "datetime(3)",
+      "Null": false,
+      "Key": "",
+      "Default": null,
+      "Extra": ""
+    }
+  ],
+  "relationsFromTable": [],
+  "relationsToTable": [],
+  "indexes": [
+    {
+      "Index": "PRIMARY",
+      "Columns": "token",
+      "Unique": 1
+    }
+  ],
+  "table": "payment_token"
+}]
+JSON;
+
+    public static function provideSchemaRaw(): iterable
+    {
+        yield 'version ' . static::VERSION_A => [self::JSON__SCHEMA_A, static::VERSION_A];
+        yield 'version ' . static::VERSION_B => [self::JSON__SCHEMA_B, static::VERSION_B];
+    }
+
+    #[DataProvider('provideSchemaRaw')]
+    public function testCreateModelFromData(string $schema, string $version): void
+    {
+        $data   = Json::decodeToList($schema);
+        $schema = Swdb\Schema::createFromData($data, $version);
+
+        self::assertSame($version, $schema->version);
+        self::assertSameSize($data, $schema->tables);
+    }
+}


### PR DESCRIPTION
## Example:

Comparison of latest `6.6.x` to `6.7.0.0` using live-introspection feature:

<img width="1788" height="1162" alt="image" src="https://github.com/user-attachments/assets/55fea674-b3ae-44f7-b4b4-a6abcd99f901" />

## Details

The `/api/_action/frosh-tools/shopware-database-diff/available-versions` shows all available version schemas from https://swdb.dev/.

The admin UI shows a searchable list of database differences in tables, fields, indexes and relations from/to respective tables. It also gives an overview of the criticality of the differences found.

The `/api/_action/frosh-tools/shopware-database-diff/{version}` endpoint calculates the database differences between the currently installed version and the selected target.

It uses the currently installed version by default, based on the schema, if available. If a fallback version is detected, the major-minor version is used (e.g. there is no `6.6.99999` schema available). All responses are cached by default.

The same endpoint supports **Live introspection**, which analyses the actual database schema and compares it to the schema of any selected version.

An external link is provided, to inspect the full schema on swdb.dev.

## Credits

- https://swdb.dev/ provided by @janschoepke.
